### PR TITLE
Adjusting chapters to have string keywords for the different chapters.

### DIFF
--- a/schema/opat-0.1.0.json
+++ b/schema/opat-0.1.0.json
@@ -37,66 +37,44 @@
       "type": "string"
     },
     "chapters": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "num": {
-            "description": "Table or chapter number.",
-            "type": "string"
-          },
-          "title": {
-            "description": "Table or chapter title.",
-            "type": "string"
-          },
-          "criteria": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "num": {
-                  "description": "Criteria number.",
-                  "type": "string"
-                },
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "description": "Name of component. E.g. Web, Electronic Docs, Authoring Tools, Software, and so on.",
-                        "type": "string"
-                      },
-                      "adherence": {
-                        "type": "object",
-                        "properties": {
-                          "level": {
-                            "description": "Conformance Level. Supports: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.\nPartially Supports: Some functionality of the product does not meet the criterion.\nDoes Not Support: The majority of product functionality does not meet the criterion.\nNot Applicable: The criterion is not relevant to the product.\nNot Evaluated: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.",
-                            "enum": [
-                              "supports",
-                              "partially-supports",
-                              "does-not-support",
-                              "not-applicable",
-                              "not-evaluated"
-                            ]
-                          },
-                          "notes": {
-                            "description": "Remarks and Explanations.",
-                            "type": "string"
-                          }
-                        },
-                        "required": ["level"]
-                      }
-                    },
-                    "required": ["name"]
-                  }
-                }
-              },
-              "required": ["num"]
+      "type": "object",
+      "properties": {
+        "success_criteria_level_a": {
+          "description": "Success criteria level A. Table/chapter 1 in all versions.",
+          "type": "object",
+          "properties": {
+            "num": {
+              "description": "Table or chapter number.",
+              "type": "string"
+            },
+            "notes": {
+              "description": "Any details or explanation about the chapter.",
+              "type": "string"
+            },
+            "criteria": {
+              "$ref": "#/definitions/criteria"
             }
-          }
+          },
+          "required": ["num"]
         },
-        "required": ["num", "title"]
+        "hardware": {
+          "description": "Hardware (chapter 4 in 508/WCAG/INT versions, chapter 8 in EU version).",
+          "type": "object",
+          "properties": {
+            "num": {
+              "description": "Table or chapter number.",
+              "type": "string"
+            },
+            "notes": {
+              "description": "Any details or explanation about the chapter.",
+              "type": "string"
+            },
+            "criteria": {
+              "$ref": "#/definitions/criteria"
+            }
+          },
+          "required": ["num"]
+        }
       }
     }
   },
@@ -119,6 +97,52 @@
         }
       },
       "required": ["email"]
+    },
+    "criteria": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "num": {
+            "description": "Criteria number.",
+            "type": "string"
+          },
+          "components": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of component. E.g. Web, Electronic Docs, Authoring Tools, Software, and so on.",
+                  "type": "string"
+                },
+                "adherence": {
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Conformance Level. Supports: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.\nPartially Supports: Some functionality of the product does not meet the criterion.\nDoes Not Support: The majority of product functionality does not meet the criterion.\nNot Applicable: The criterion is not relevant to the product.\nNot Evaluated: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.",
+                      "enum": [
+                        "supports",
+                        "partially-supports",
+                        "does-not-support",
+                        "not-applicable",
+                        "not-evaluated"
+                      ]
+                    },
+                    "notes": {
+                      "description": "Remarks and Explanations.",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["level"]
+                }
+              },
+              "required": ["name"]
+            }
+          }
+        },
+        "required": ["num"]
+      }
     }
   }
 }

--- a/tests/examples/valid.yaml
+++ b/tests/examples/valid.yaml
@@ -7,8 +7,8 @@ contact:
   email: mike.gifford@civicactions.com
 notes: Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
 chapters:
-  - num: "1"
-    title: "Success Criteria, Level A"
+  success_criteria_level_a:
+    num: "1"
     criteria:
       - num: "1.1.1"
         components:
@@ -44,3 +44,6 @@ chapters:
             adherence:
               level: does-not-support
               notes: There is no additional support for authors within the authoring interface to explain how this can be done.
+  hardware:
+    num: "4"
+    notes: "Drupal is a web application. Hardware accessibility criteria is not applicable."

--- a/tests/validate-opat-chapters.test.ts
+++ b/tests/validate-opat-chapters.test.ts
@@ -11,10 +11,9 @@ describe("Validate OPAT chapters", () => {
     contact: {
       email: "mike.gifford@civicactions.com",
     },
-    chapters: [
-      {
+    chapters: {
+      success_criteria_level_a: {
         num: "1",
-        title: "Success Criteria, Level A",
         criteria: [
           {
             num: "1.1.1",
@@ -30,11 +29,12 @@ describe("Validate OPAT chapters", () => {
           },
         ],
       },
-      {
-        num: "2",
-        title: "Success Criteria, Level AA",
+      hardware: {
+        num: "4",
+        notes:
+          "Drupal is a web application. Hardware accessibility criteria is not applicable.",
       },
-    ],
+    },
   };
   const invalidJSON1 = {
     title: "Drupal Accessibility Conformance Report",
@@ -44,12 +44,10 @@ describe("Validate OPAT chapters", () => {
     contact: {
       email: "mike.gifford@civicactions.com",
     },
-    chapters: [
-      {
-        foo: 3,
-        bar: 4,
-      },
-    ],
+    chapters: {
+      success_criteria_level_a: 3,
+      hardware: 4,
+    },
   };
   const invalidJSON2 = {
     title: "Drupal Accessibility Conformance Report",
@@ -59,13 +57,12 @@ describe("Validate OPAT chapters", () => {
     contact: {
       email: "mike.gifford@civicactions.com",
     },
-    chapters: [
-      {
+    chapters: {
+      success_criteria_level_a: {
         num: "1",
-        title: "Success Criteria, Level A",
         criteria: ["1.1.1", "1.4.1"],
       },
-    ],
+    },
   };
   const invalidJSON3 = {
     title: "Drupal Accessibility Conformance Report",
@@ -75,25 +72,24 @@ describe("Validate OPAT chapters", () => {
     contact: {
       email: "mike.gifford@civicactions.com",
     },
-    chapters: [
-      {
+    chapters: {
+      success_criteria_level_a: {
         num: "1",
-        title: "Success Criteria, Level A",
         criteria: [
           {
             num: "1.1.1",
             components: [
               {
-                name: "website",
+                name: "web",
                 adherence: {
-                  level: "does not support",
+                  level: "does not supports",
                 },
               },
             ],
           },
         ],
       },
-    ],
+    },
   };
   let result = null;
 
@@ -107,8 +103,8 @@ describe("Validate OPAT chapters", () => {
     result = validateOPAT(invalidJSON1, validSchema);
     expect(result.result).to.equal(false);
     expect(result.message).to.equal(
-      "Invalid: data/chapters/0 must have required property 'num', " +
-        "data/chapters/0 must have required property 'title'"
+      "Invalid: data/chapters/success_criteria_level_a must be object, " +
+        "data/chapters/hardware must be object"
     );
   });
 
@@ -116,8 +112,8 @@ describe("Validate OPAT chapters", () => {
     result = validateOPAT(invalidJSON2, validSchema);
     expect(result.result).to.equal(false);
     expect(result.message).to.equal(
-      "Invalid: data/chapters/0/criteria/0 must be object, " +
-        "data/chapters/0/criteria/1 must be object"
+      "Invalid: data/chapters/success_criteria_level_a/criteria/0 must be object, " +
+        "data/chapters/success_criteria_level_a/criteria/1 must be object"
     );
   });
 
@@ -125,7 +121,7 @@ describe("Validate OPAT chapters", () => {
     result = validateOPAT(invalidJSON3, validSchema);
     expect(result.result).to.equal(false);
     expect(result.message).to.equal(
-      "Invalid: data/chapters/0/criteria/0/components/0/adherence/level must be equal to one of the allowed values"
+      "Invalid: data/chapters/success_criteria_level_a/criteria/0/components/0/adherence/level must be equal to one of the allowed values"
     );
   });
 });


### PR DESCRIPTION
In this PR we switch chapters from freeform array to object with keywords. Examples used are Level A and Hardware. This is what the schema and valid example would look like:

<details>
  <summary>Schema</summary>

  ```json
  {
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "opat-0.1.0.json",
    "title": "OPAT",
    "description": "Open Product Accessibility Template (OPAT) as a YAML file.",
    "type": "object",
    "properties": {
      "title": {
        "description": "The title of the report in the heading format of '[Company Name] Accessibility Conformance Report'.",
        "type": "string"
      },
      "product": {
        "description": "Product information",
        "type": "object",
        "properties": {
          "name": {
            "description": "Product name.",
            "type": "string"
          },
          "version": {
            "description": "Product version if available.",
            "type": "string"
          },
          "description": {
            "description": "A brief description of the product.",
            "type": "string"
          }
        },
        "required": ["name"]
      },
      "contact": {
        "description": "Contact information.",
        "$ref": "#/definitions/contact"
      },
      "notes": {
        "description": "Any details or explanation about the product or the report.",
        "type": "string"
      },
      "chapters": {
        "type": "object",
        "properties": {
          "success_criteria_level_a": {
            "description": "Success criteria level A. Table/chapter 1 in all versions.",
            "type": "object",
            "properties": {
              "num": {
                "description": "Table or chapter number.",
                "type": "string"
              },
              "notes": {
                "description": "Any details or explanation about the chapter.",
                "type": "string"
              },
              "criteria": {
                "$ref": "#/definitions/criteria"
              }
            },
            "required": ["num"]
          },
          "hardware": {
            "description": "Hardware (chapter 4 in 508/WCAG/INT versions, chapter 8 in EU version).",
            "type": "object",
            "properties": {
              "num": {
                "description": "Table or chapter number.",
                "type": "string"
              },
              "notes": {
                "description": "Any details or explanation about the chapter.",
                "type": "string"
              },
              "criteria": {
                "$ref": "#/definitions/criteria"
              }
            },
            "required": ["num"]
          }
        }
      }
    },
    "required": ["title", "product", "contact"],
    "definitions": {
      "contact": {
        "type": "object",
        "properties": {
          "email": {
            "type": "string"
          },
          "name": {
            "type": "string"
          },
          "address": {
            "type": "string"
          },
          "phone": {
            "type": "string"
          }
        },
        "required": ["email"]
      },
      "criteria": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "num": {
              "description": "Criteria number.",
              "type": "string"
            },
            "components": {
              "type": "array",
              "items": {
                "type": "object",
                "properties": {
                  "name": {
                    "description": "Name of component. E.g. Web, Electronic Docs, Authoring Tools, Software, and so on.",
                    "type": "string"
                  },
                  "adherence": {
                    "type": "object",
                    "properties": {
                      "level": {
                        "description": "Conformance Level. Supports: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.\nPartially Supports: Some functionality of the product does not meet the criterion.\nDoes Not Support: The majority of product functionality does not meet the criterion.\nNot Applicable: The criterion is not relevant to the product.\nNot Evaluated: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.",
                        "enum": [
                          "supports",
                          "partially-supports",
                          "does-not-support",
                          "not-applicable",
                          "not-evaluated"
                        ]
                      },
                      "notes": {
                        "description": "Remarks and Explanations.",
                        "type": "string"
                      }
                    },
                    "required": ["level"]
                  }
                },
                "required": ["name"]
              }
            }
          },
          "required": ["num"]
        }
      }
    }
  }
  ```

</details>
<details>
  <summary>YAML</summary>

  ```yaml
title: Drupal Accessibility Conformance Report
product:
  name: Drupal
  version: "9.1"
  description: Content Management System
contact:
  email: mike.gifford@civicactions.com
notes: Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
chapters:
  success_criteria_level_a:
    num: "1"
    criteria:
      - num: "1.1.1"
        components:
          - name: "web"
            adherence:
              level: "supports"
              notes: Drupal 8 requires alt text for images by default.
          - name: "electronic-docs"
            adherence:
              level: "supports"
              notes: Some non-textual content in the documentation does not provide a textual alternative.
          - name: "software"
            adherence:
              level: "not-applicable"
          - name: "authoring-tool"
            adherence:
              level: "supports"
              notes: The back end of Drupal Core was built to be  WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue #3002770.
      - num: "1.2.2"
        components:
          - name: "web"
            adherence:
              level: partially-supports
              notes: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.
          - name: "electronic-docs"
            adherence:
              level: partially-supports
              notes: This is not explicitly defined in the documentation.
          - name: "software"
            adherence:
              level: not-applicable
          - name: "authoring-tool"
            adherence:
              level: does-not-support
              notes: There is no additional support for authors within the authoring interface to explain how this can be done.
  hardware:
    num: "4"
    notes: "Drupal is a web application. Hardware accessibility criteria is not applicable."
  ```
</details>