### PR TITLE
Fleshing out WCAG 2.0 A 1.1, 1.2 & 1.3 issues

### DIFF
--- a/catalog/2.4-edition-508-wcag-2.0.yaml
+++ b/catalog/2.4-edition-508-wcag-2.0.yaml
@@ -16,19 +16,19 @@ chapters:
         label: Captions (Prerecorded)
         key: media-equiv-audio-desc-only
         components: [web, "electronic-docs", software, "authoring-tool"]
-     - id: 1.2.3
+      - id: 1.2.3
         label: Audio Description or Media Alternative (Prerecorded)
         key: media-equiv-real-time-captions
         components: [web, "electronic-docs", software, "authoring-tool"]
-     - id: 1.3.1
+      - id: 1.3.1
         label: Info and Relationships
         key: content-structure-separation-sequence
         components: [web, "electronic-docs", software, "authoring-tool"]
-     - id: 1.3.2
+      - id: 1.3.2
         label: Meaningful Sequence
         key: content-structure-separation-sequence
         components: [web, "electronic-docs", software, "authoring-tool"]
-     - id: 1.3.3
+      - id: 1.3.3
         label: Sensory Characteristics
         key: content-structure-separation-understanding
         components: [web, "electronic-docs", software, "authoring-tool"]

--- a/catalog/2.4-edition-508-wcag-2.0.yaml
+++ b/catalog/2.4-edition-508-wcag-2.0.yaml
@@ -5,12 +5,32 @@ chapters:
     order: 1
     criteria:
       - id: 1.1.1
-        label: Non-text Content (Level A)
+        label: Non-text Content
         key: text-equiv
         components: [web, "electronic-docs", software, "authoring-tool"]
+     - id: 1.2.1
+        label: Audio-only and Video-only (Prerecorded)
+        key: media-equiv-captions
+        components: [web, "electronic-docs", software, "authoring-tool"]
       - id: 1.2.2
-        label: 1.2.2 Captions (Prerecorded) (Level A)
-        key: media-equiv
+        label: Captions (Prerecorded)
+        key: media-equiv-audio-desc-only
+        components: [web, "electronic-docs", software, "authoring-tool"]
+     - id: 1.2.3
+        label: Audio Description or Media Alternative (Prerecorded)
+        key: media-equiv-real-time-captions
+        components: [web, "electronic-docs", software, "authoring-tool"]
+     - id: 1.3.1
+        label: Info and Relationships
+        key: content-structure-separation-sequence
+        components: [web, "electronic-docs", software, "authoring-tool"]
+     - id: 1.3.2
+        label: Meaningful Sequence
+        key: content-structure-separation-sequence
+        components: [web, "electronic-docs", software, "authoring-tool"]
+     - id: 1.3.3
+        label: Sensory Characteristics
+        key: content-structure-separation-understanding
         components: [web, "electronic-docs", software, "authoring-tool"]
   - id: hardware
     label: Hardware

--- a/catalog/2.4-edition-508-wcag-2.0.yaml
+++ b/catalog/2.4-edition-508-wcag-2.0.yaml
@@ -8,7 +8,7 @@ chapters:
         label: Non-text Content
         key: text-equiv
         components: [web, "electronic-docs", software, "authoring-tool"]
-     - id: 1.2.1
+      - id: 1.2.1
         label: Audio-only and Video-only (Prerecorded)
         key: media-equiv-captions
         components: [web, "electronic-docs", software, "authoring-tool"]


### PR DESCRIPTION
This was largely an experiment.

- Why are we using "label" vs W3C's use of "handle"?
- Why use "key" vs either "id" or "alt_id"?
- Are we going to have confusion between "id" in OPAT - "1.3.3" & the id from the W3C - "WCAG2:sensory-characteristics"?

I don't think that the label (or handle) should include either the id or the level. It might be easier programmatically, but I'm worried about it introducing problems down the line. Plus it is redundant information. 

Anyways here for discussion.