### PR TITLE
Added vendor, evaluation methods, legal disclaimer. Updated contact to include website and updated example to test output.

### DIFF
--- a/opat/drupal-9.yaml
+++ b/opat/drupal-9.yaml
@@ -4,8 +4,15 @@ product:
   version: "9.1"
   description: Content Management System
 contact:
+  name: Mike Gifford
+  company_name: CivicActions
+  address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549
   email: mike.gifford@civicactions.com
+  phone: (510) 408-7510
+  website: https://civicactions.com/
 notes: Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+evaluation_methods_used: Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+legal_disclaimer: The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
 chapters:
   success_criteria_level_a:
     notes: "Drupal doesn't make a strong distinction between the front-end & back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation."

--- a/schema/opat-0.1.0.json
+++ b/schema/opat-0.1.0.json
@@ -32,8 +32,20 @@
       "description": "Contact information.",
       "$ref": "#/definitions/contact"
     },
+    "vendor": {
+      "description": "Vendor information.",
+      "$ref": "#/definitions/contact"
+    },
     "notes": {
       "description": "Any details or explanation about the product or the report.",
+      "type": "string"
+    },
+    "evaluation_methods_used": {
+      "description": "Include a description of evaluation methods used to complete the OPAT for the product under test.",
+      "type": "string"
+    },
+    "legal_disclaimer": {
+      "description": "Area for any legal disclaimer text required by your organization..",
       "type": "string"
     },
     "chapters": {
@@ -99,16 +111,22 @@
     "contact": {
       "type": "object",
       "properties": {
-        "email": {
+        "name": {
           "type": "string"
         },
-        "name": {
+        "company_name": {
           "type": "string"
         },
         "address": {
           "type": "string"
         },
+        "email": {
+          "type": "string"
+        },
         "phone": {
+          "type": "string"
+        },
+        "website": {
           "type": "string"
         }
       },

--- a/templates/opat-0.1.0.handlebars
+++ b/templates/opat-0.1.0.handlebars
@@ -13,14 +13,34 @@ Based on {{catalog.title}}
 {{product.description}}
 {{/if}}
 
+{{#if contact}}
 ## Contact Information
-{{#if contact.name}}Name: {{contact.name}}{{/if}}
-{{#if contact.address}}Address: {{contact.address}}{{/if}}
-Email: {{contact.email}}
-{{#if contact.phone}}Phone: {{contact.phone}}{{/if}}
+{{#if contact.name}}- Name: {{contact.name}}{{/if}}
+{{#if contact.company_name}}- Company: {{contact.company_name}}{{/if}}
+{{#if contact.address}}- Address: {{contact.address}}{{/if}}
+{{#if contact.email}}- Email: {{contact.email}}{{/if}}
+{{#if contact.phone}}- Phone: {{contact.phone}}{{/if}}
+{{#if contact.website}}- Website: {{contact.website}}{{/if}}
+{{/if}}
+{{#if vendor}}
+## Vendor Information
+{{#if vendor.name}}- Name: {{vendor.name}}{{/if}}
+{{#if vendor.company_name}}- Company: {{vendor.company_name}}{{/if}}
+{{#if vendor.address}}- Address: {{vendor.address}}{{/if}}
+{{#if vendor.email}}- Email: {{vendor.email}}{{/if}}
+{{#if vendor.phone}}- Phone: {{vendor.phone}}{{/if}}
+{{#if vendor.website}}- Website: {{vendor.website}}{{/if}}
+{{/if}}
 
+{{#if notes}}
 ## Notes
 {{notes}}
+{{/if}}
+
+{{#if evaluation_methods_used}}
+## Evaluation Methods Used
+{{evaluation_methods_used}}
+{{/if}}
 
 ## Terms
 The terms used in the Conformance Level information are defined as follows:
@@ -46,3 +66,8 @@ Notes: {{data-category.notes}}
 {{/if}}
 {{/with}}
 {{/each}}
+
+{{#if legal_disclaimer}}
+## Legal Disclaimer {{#if contact.company_name}}({{contact.company_name}}){{/if}}
+{{legal_disclaimer}}
+{{/if}}

--- a/tests/examples/valid.markdown
+++ b/tests/examples/valid.markdown
@@ -12,13 +12,18 @@ Drupal 9.1
 Content Management System
 
 ## Contact Information
-
-
-Email: mike.gifford@civicactions.com
-
+- Name: Mike Gifford
+- Company: CivicActions
+- Address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549
+- Email: mike.gifford@civicactions.com
+- Phone: (510) 408-7510
+- Website: https://civicactions.com/
 
 ## Notes
 Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+
+## Evaluation Methods Used
+Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
 
 ## Terms
 The terms used in the Conformance Level information are defined as follows:
@@ -43,3 +48,7 @@ The terms used in the Conformance Level information are defined as follows:
 ## Chapter 4: Hardware
 
 Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
+
+
+## Legal Disclaimer (CivicActions)
+The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.

--- a/tests/examples/valid.yaml
+++ b/tests/examples/valid.yaml
@@ -4,8 +4,15 @@ product:
   version: "9.1"
   description: Content Management System
 contact:
+  name: Mike Gifford
+  company_name: CivicActions
+  address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549
   email: mike.gifford@civicactions.com
+  phone: (510) 408-7510
+  website: https://civicactions.com/
 notes: Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
+evaluation_methods_used: Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+legal_disclaimer: The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
 chapters:
   success_criteria_level_a:
     criteria:


### PR DESCRIPTION
Following direction from https://github.com/GSA/open-product-accessibility-template/issues/14#issuecomment-892760324 with the following tweaks:

* Split vendor into its own optional line but uses the same 'contact' definitions i.e same fields as "contact".
* Added company_name and website (instead of URL) to the 'contact' definition.
* Updated output including example so we can new the fields in action.
* Separate pull request to tackle 'Applicable Standards/Guidelines' as we can derive that from the catalog.

For the output using https://accessibility.deque.com/hubfs/Sample-VPAT.pdf this as another reference and decided that bullets in markdown were easier than line breaks for the contact information section.