### PR TITLE
Adding sub headings to output

### DIFF
--- a/catalog/2.4-edition-wcag-2.0-508.yaml
+++ b/catalog/2.4-edition-wcag-2.0-508.yaml
@@ -4,12 +4,21 @@ standards:
     label: Web Content Accessibility Guidelines 2.0
     report_heading: WCAG 2.0 Report
     url: https://www.w3.org/TR/WCAG20/
+    chapters:
+      - success_criteria_level_a
+      - success_criteria_level_aa
+      - success_criteria_level_aaa
   - id: "508"
     label: >-
       Revised Section 508 standards published January 18, 2017 and corrected
       January 22, 2018
     report_heading: Revised Section 508 Report
     url: https://www.access-board.gov/ict/
+    chapters:
+      - functional_performance_criteria
+      - hardware
+      - software
+      - support_documentation_and_services
 chapters:
   - id: success_criteria_level_a
     label: "Table 1: Success Criteria, Level A"

--- a/catalog/data/508.yaml
+++ b/catalog/data/508.yaml
@@ -4,6 +4,13 @@ standard:
     label: "Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018"
     report_heading: "Revised Section 508 Report"
     url: https://www.access-board.gov/ict/
+    chapters:
+      [
+        functional_performance_criteria,
+        hardware,
+        software,
+        support_documentation_and_services,
+      ]
 chapters:
   - id: functional_performance_criteria
     label: "Chapter 3: Functional Performance Criteria (FPC)"

--- a/catalog/data/wcag-2.0.yaml
+++ b/catalog/data/wcag-2.0.yaml
@@ -4,6 +4,12 @@ standard:
     label: "Web Content Accessibility Guidelines 2.0"
     report_heading: "WCAG 2.0 Report"
     url: https://www.w3.org/TR/WCAG20/
+    chapters:
+      [
+        success_criteria_level_a,
+        success_criteria_level_aa,
+        success_criteria_level_aaa,
+      ]
 chapters:
   - id: success_criteria_level_a
     label: "Table 1: Success Criteria, Level A"

--- a/opat/drupal-9.markdown
+++ b/opat/drupal-9.markdown
@@ -42,7 +42,8 @@ The terms used in the Conformance Level information are defined as follows:
 - **Not Applicable**: The criterion is not relevant to the product.
 - **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
 
-## Table 1: Success Criteria, Level A
+## WCAG 2.0 Report
+### Table 1: Success Criteria, Level A
 
 Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp; back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation.
 
@@ -74,7 +75,7 @@ Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp;
 | 4.1.1 Parsing | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li><li>**Electronic Docs**: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li><li>**Authoring Tool**: Generally parsing is very well supported, but there are a few places where this needs to be improved - Drupal issue 1852090 and 3144948.</li> </ul> |
 | 4.1.2 Name, Role, Value | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Public pages support this criterion.</li><li>**Electronic Docs**: Public pages support this criterion.</li><li>**Authoring Tool**: This is generally well supported, but there are places where it has been overlooked. Drupal issue 3144948, 3019487, and 3085545.</li> </ul> |
 
-## Table 2: Success Criteria, Level AA
+### Table 2: Success Criteria, Level AA
 
 
 | Criteria | Conformance Level | Remarks and Explanations |
@@ -93,7 +94,7 @@ Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp;
 | 3.3.3 Error Suggestion | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Not Applicable</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li><li>**Authoring Tool**: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li> </ul> |
 | 3.3.4 Error Prevention (Legal, Financial, Data) | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Partially Supports</li> </ul> | <ul><li>**Web**: By default users can editing content which they own.</li><li>**Electronic Docs**: Documentation could be improved.</li><li>**Authoring Tool**: There is nothing to differentiate editing financial or legal data from any other data managed by Drupal.</li> </ul> |
 
-## Table 3: Success Criteria, Level AAA
+### Table 3: Success Criteria, Level AAA
 
 Notes: Where possible the Drupal community strives to exceed AA compliance.
 
@@ -123,7 +124,8 @@ Notes: Where possible the Drupal community strives to exceed AA compliance.
 | 3.3.5 Help | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
 | 3.3.6 Error Prevention (All) | <ul><li>**Web**: Not Applicable</li> </ul> | <ul> </ul> |
 
-## Chapter 3: Functional Performance Criteria (FPC)
+## Revised Section 508 Report
+### Chapter 3: Functional Performance Criteria (FPC)
 
 Notes: Not applicable.
 
@@ -139,15 +141,15 @@ Notes: Not applicable.
 | 302.8 With Limited Reach and Strength | <ul><li>Supports</li> </ul> | <ul><li>Drupal&#x27;s interface does not restrict users with limited reach or strength.</li> </ul> |
 | 302.9 With Limited Language, Cognitive, and Learning Abilities | <ul><li>Not Applicable</li> </ul> | <ul> </ul> |
 
-## Chapter 4: Hardware
+### Chapter 4: Hardware
 
 Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
 
-## Chapter 5: Software
+### Chapter 5: Software
 
 Notes: Drupal is a web application. Software accessibility criteria is not applicable.
 
-## Chapter 6: Support Documentation and Services
+### Chapter 6: Support Documentation and Services
 
 Notes: Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
 

--- a/opat/drupal-9.markdown
+++ b/opat/drupal-9.markdown
@@ -6,7 +6,7 @@ Based on VPAT® 2.4 Revised Section 508 Edition
 Drupal 9.1
 
 ## Report Date
-8/6/2021
+8/9/2021
 
 ## Product Description
 Content Management System
@@ -25,6 +25,14 @@ Links to the issues identified are included where possible to ensure that this i
 
 ## Evaluation Methods Used
 Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+
+## Applicable Standards/Guidelines
+This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+| Standard/Guideline | Included In Report |
+| --- | --- |
+| [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/) | |
+| [Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018](https://www.access-board.gov/ict/) | |
 
 ## Terms
 The terms used in the Conformance Level information are defined as follows:

--- a/schema/opat-catalog-0.1.0.json
+++ b/schema/opat-catalog-0.1.0.json
@@ -33,6 +33,13 @@
           "url": {
             "description": "Standard URL.",
             "type": "string"
+          },
+          "chapters": {
+            "description": "List of chapters in standard.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": ["id", "label", "report_heading", "url"]

--- a/src/outputOPAT.ts
+++ b/src/outputOPAT.ts
@@ -19,6 +19,14 @@ export function outputOPAT(
     const date = new Date();
     data.now = date.toLocaleDateString();
 
+    Handlebars.registerHelper("catalogChapter", function (chapterId) {
+      for (const chapter of catalogData.chapters) {
+        if (chapter.id === chapterId) {
+          return chapter;
+        }
+      }
+    });
+
     Handlebars.registerHelper(
       "catalogCriteriaLabel",
       function (chapterId, criteriaNum) {

--- a/templates/opat-0.1.0.handlebars
+++ b/templates/opat-0.1.0.handlebars
@@ -43,6 +43,15 @@ Based on {{catalog.title}}
 {{evaluation_methods_used}}
 {{/if}}
 
+## Applicable Standards/Guidelines
+This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+| Standard/Guideline | Included In Report |
+| --- | --- |
+{{#each catalog.standards as |catalog-standard|}}
+| [{{catalog-standard.label}}]({{catalog-standard.url}}) | |
+{{/each}}
+
 ## Terms
 The terms used in the Conformance Level information are defined as follows:
 {{#each catalog.terms as |catalog-term|}}

--- a/templates/opat-0.1.0.handlebars
+++ b/templates/opat-0.1.0.handlebars
@@ -58,10 +58,13 @@ The terms used in the Conformance Level information are defined as follows:
 - **{{catalog-term.label}}**: {{catalog-term.description}}
 {{/each}}
 
-{{#each catalog.chapters as |catalog-chapter|}}
-## {{catalog-chapter.label}}
+{{#each catalog.standards as |catalog-standard|}}
+## {{catalog-standard.report_heading}}
+{{#each catalog-standard.chapters as |catalog-standard-chapter|}}
+{{#with (catalogChapter catalog-standard-chapter) as |catalog-chapter|}}
+### {{catalog-chapter.label}}
 
-{{#with (lookup ../chapters catalog-chapter.id) as |data-category|}}
+{{#with (lookup ../../../chapters catalog-chapter.id) as |data-category|}}
 {{#if data-category.notes}}
 Notes: {{data-category.notes}}
 {{/if}}
@@ -75,6 +78,8 @@ Notes: {{data-category.notes}}
 
 {{/if}}
 {{/with}}
+{{/with}}
+{{/each}}
 {{/each}}
 
 {{#if legal_disclaimer}}

--- a/tests/examples/valid.markdown
+++ b/tests/examples/valid.markdown
@@ -49,7 +49,8 @@ The terms used in the Conformance Level information are defined as follows:
 - **Not Applicable**: The criterion is not relevant to the product.
 - **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
 
-## Table 1: Success Criteria, Level A
+## WCAG 2.0 Report
+### Table 1: Success Criteria, Level A
 
 
 | Criteria | Conformance Level | Remarks and Explanations |
@@ -57,19 +58,20 @@ The terms used in the Conformance Level information are defined as follows:
 | 1.1.1 Non-text Content | <ul><li>**Web**: Supports</li><li>**Electronic Docs**: Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Supports</li> </ul> | <ul><li>**Web**: Drupal 8 requires alt text for images by default.</li><li>**Electronic Docs**: Some non-textual content in the documentation does not provide a textual alternative.</li><li>**Authoring Tool**: The back end of Drupal Core was built to be WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue 3002770.</li> </ul> |
 | 1.2.2 Captions (Prerecorded) | <ul><li>**Web**: Partially Supports</li><li>**Electronic Docs**: Partially Supports</li><li>**Software**: Not Applicable</li><li>**Authoring Tool**: Does Not Support</li> </ul> | <ul><li>**Web**: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.</li><li>**Electronic Docs**: This is not explicitly defined in the documentation.</li><li>**Authoring Tool**: There is no additional support for authors within the authoring interface to explain how this can be done.</li> </ul> |
 
-## Table 2: Success Criteria, Level AA
+### Table 2: Success Criteria, Level AA
 
-## Table 3: Success Criteria, Level AAA
+### Table 3: Success Criteria, Level AAA
 
-## Chapter 3: Functional Performance Criteria (FPC)
+## Revised Section 508 Report
+### Chapter 3: Functional Performance Criteria (FPC)
 
-## Chapter 4: Hardware
+### Chapter 4: Hardware
 
 Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
 
-## Chapter 5: Software
+### Chapter 5: Software
 
-## Chapter 6: Support Documentation and Services
+### Chapter 6: Support Documentation and Services
 
 
 ## Legal Disclaimer (CivicActions)

--- a/tests/examples/valid.markdown
+++ b/tests/examples/valid.markdown
@@ -6,7 +6,7 @@ Based on VPAT® 2.4 Revised Section 508 Edition
 Drupal 9.1
 
 ## Report Date
-8/6/2021
+8/9/2021
 
 ## Product Description
 Content Management System
@@ -32,6 +32,14 @@ Links to the issues identified are included where possible to ensure that this i
 
 ## Evaluation Methods Used
 Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
+
+## Applicable Standards/Guidelines
+This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+| Standard/Guideline | Included In Report |
+| --- | --- |
+| [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/) | |
+| [Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018](https://www.access-board.gov/ict/) | |
 
 ## Terms
 The terms used in the Conformance Level information are defined as follows:


### PR DESCRIPTION
Partially solves todos from https://github.com/GSA/open-product-accessibility-template/issues/95#issue-962006395

* Fix the table/chapter output so to differentiate 'Table 3: Success Criteria, Level AAA' and 'Chapter 3: Functional Performance Criteria (FPC)'
* Add headings before table and chapters to speak to WCAG and 508.