### PR TITLE
Html template

### DIFF
--- a/.github/workflows/drupal-output.yaml
+++ b/.github/workflows/drupal-output.yaml
@@ -15,11 +15,14 @@ jobs:
       - name: Install dependencies.
         run: npm install
 
-      - name: Output.
+      - name: Output markdown.
         run: npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o output/drupal-9.markdown
+
+      - name: Output HTML.
+        run: npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o output/drupal-9.html
 
       - name: Download output.
         uses: actions/upload-artifact@v2
         with:
           name: drupal-9
-          path: output/drupal-9.markdown
+          path: output/drupal-9.*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 test/*.js
 src/*.js
 output/*.markdown
+output/*.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,6 @@ dist
 coverage
 templates
 tests/examples/*.markdown
+tests/examples/*.html
 opat/*.markdown
+opat/*.html

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,14 +109,16 @@ The command uses [handlebars](https://handlebarsjs.com/) and the templates defin
 
 ### Examples
 
-We checked in an example of the markdown output in `tests/examples/valid.markdown` and `opat/drupal-9.markdown`. To regenerate the examples run the following commands and commit the changes:
+We checked in an example of the markdown and HTML output in `tests/examples` and `opat`. To regenerate the examples run the following commands and commit the changes:
 
 ```bash
 npm run generate-example-output # Full command `npx ts-node src/opat.ts output -f tests/examples/valid.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o tests/examples/valid.markdown`
 npm run generate-drupal-output # Full command `npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o opat/drupal-9.markdown`
+npm run generate-example-html # Full command `npx ts-node src/opat.ts output -f tests/examples/valid.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o tests/examples/valid.html`
+npm run generate-drupal-html # Full command `npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o opat/drupal-9.html`
 ```
 
-We also have a GitHub action called 'Drupal 9 OPAT output' that will generate the markdown version of the Drupal 9 OPAT. It is run on pull requests, and the output can be downloaded to double-check it is matching expectations.
+We also have a GitHub action called 'Drupal 9 OPAT output' that will generate the markdown and HTML versions of the Drupal 9 OPAT. It is run on pull requests, and the output can be downloaded to double-check it is matching expectations.
 
 The tests also generates output that is stored in the `output` directory but is not tracked by git.
 

--- a/opat/drupal-9.html
+++ b/opat/drupal-9.html
@@ -1,0 +1,2004 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Drupal Accessibility Conformance Report</title>
+    <meta name="description" content="Content Management System" />
+  </head>
+  <body>
+    <header>
+      <h1>Drupal Accessibility Conformance Report</h1>
+
+      Based on VPAT® 2.4 Revised Section 508 Edition
+    </header>
+    <main>
+      <h2>Name of Product/Version</h2>
+      Drupal 9.1
+
+      <h2>Report Date</h2>
+      8/13/2021
+
+      <h2>Product Description</h2>
+      Content Management System
+
+      <h2>Contact Information</h2>
+      <h3>Author Information</h3>
+      <ul>
+        <li>Name: Mike Gifford</li>
+        <li>Company: CivicActions</li>
+        <li>Address: 3527 Mt Diablo Blvd, Unit 269, Lafayette, CA 94549</li>
+        <li>Email: mike.gifford@civicactions.com</li>
+        <li>Phone: (510) 408-7510</li>
+        <li>Website: https://civicactions.com/</li>
+      </ul>
+
+      <h2>Notes</h2>
+      Links to the issues identified are included where possible to ensure that
+      this is a living document where outstanding issues are regularly reviewed
+      for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A
+      and B. Incorporating feedback from the Drupal community.
+
+      <h2>Evaluation Methods Used</h2>
+      Use of automated tools like WAVE and Accessibility Insights. Manual
+      keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The
+      evaluation process also includes a review of the Drupal Core accessibility
+      issue queue.
+
+      <h2>Applicable Standards/Guidelines</h2>
+      This report covers the degree of conformance for the following
+      accessibility standard/guidelines:
+
+      <table>
+        <thead>
+          <tr>
+            <th>Standard/Guideline</th>
+            <th>Included In Report</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/"
+                >Web Content Accessibility Guidelines 2.0</a
+              >
+            </td>
+            <td>
+              <ul>
+                <li>Table 1: Success Criteria, Level A</li>
+                <li>Table 2: Success Criteria, Level AA</li>
+                <li>Table 3: Success Criteria, Level AAA</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/"
+                >Revised Section 508 standards published January 18, 2017 and
+                corrected January 22, 2018</a
+              >
+            </td>
+            <td>
+              <ul>
+                <li>Chapter 3: Functional Performance Criteria (FPC)</li>
+                <li>Chapter 4: Hardware</li>
+                <li>Chapter 5: Software</li>
+                <li>Chapter 6: Support Documentation and Services</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Terms</h2>
+      The terms used in the Conformance Level information are defined as
+      follows:
+      <ul>
+        <li>
+          <strong>Supports</strong>: The functionality of the product has at
+          least one method that meets the criterion without known defects or
+          meets with equivalent facilitation.
+        </li>
+        <li>
+          <strong>Partially Supports</strong>: Some functionality of the product
+          does not meet the criterion.
+        </li>
+        <li>
+          <strong>Does Not Support</strong>: The majority of product
+          functionality does not meet the criterion.
+        </li>
+        <li>
+          <strong>Not Applicable</strong>: The criterion is not relevant to the
+          product.
+        </li>
+        <li>
+          <strong>Not Evaluated</strong>: The product has not been evaluated
+          against the criterion. This can be used only in WCAG 2.0 Level AAA.
+        </li>
+      </ul>
+
+      <h2>WCAG 2.0 Report</h2>
+      <h3>Table 1: Success Criteria, Level A</h3>
+
+      Notes: Drupal doesn&#x27;t make a strong distinction between the front-end
+      &amp; back-end accessibility. Many administration interfaces can be
+      exposed to users in a more interactive site. Generally this report focuses
+      the Conformance Level / Remarks and Explainations so that Web comments are
+      about elements that are typically public, while Authoring Tool is
+      typically for authors and administrators. The goal of the authoring
+      interface is to support ATAG 2.0 AA (Part A and B). The Drupal community
+      strives to beek up with the latest WCAG recommendation.
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
+                1.1.1 Non-text Content
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Drupal 8 requires alt text for images by
+                  default.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Some non-textual content in
+                  the documentation does not provide a textual alternative.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The back end of Drupal Core
+                  was built to be WCAG 2.0 AA compliant and non-text content in
+                  the administration interface has a textual equivalent. Audio
+                  and video can be added to the media library, but Core does not
+                  provide tools to manage transcripts and captions/subtitles for
+                  local video and audio - Drupal issue 3002770.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt">
+                1.2.1 Audio-only and Video-only (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Authors can satisfy 1.2.1 Audio-only and
+                  Video-only (Prerecorded) by using text on the same page.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: This is not explicitly
+                  defined in the documentation.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is no additional
+                  support for authors within the authoring interface to explain
+                  how this can be done.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
+                1.2.2 Captions (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Does Not Support</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: The file module in Core lets authors
+                  upload audio and video content, and output &lt;audio&gt; and
+                  &lt;video&gt; elements and does not support captions.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Drupal does not support, let
+                  alone require users to include captions. Hard coding open
+                  captions is presently the only way to satisfy this in Core.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">
+                1.2.3 Audio Description or Media Alternative (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Does Not Support</li>
+                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Audio files can be uploaded, but there
+                  is no way to associate captions in Core.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: There is no documentation on
+                  how to properly convey pre-recorded audio descriptions.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is no audio in the
+                  authoring interface of Drupal Core, but there is no support
+                  for authors to upload accessible audio files.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
+              >
+                1.3.1 Info and Relationships
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Information is structured into logical
+                  relationships. Navigational lists are well used to group
+                  information. Forms have a visual and semantic representation
+                  for required fields.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Information is structured
+                  into logical relationships. Navigational lists are well used
+                  to group information.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The authoring environment was
+                  constructed to support ATAG 2.0 AA (Part A and B).
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
+              >
+                1.3.2 Meaningful Sequence
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Drupal Core has been extensively tested
+                  with keyboard only users. As a proudly multilingual CMS,
+                  Drupal provides support for bidirectional navigation.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The authoring environment was
+                  constructed to support ATAG 2.0 AA (Part A and B).
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
+              >
+                1.3.3 Sensory Characteristics
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Where possible Drupal Core uses
+                  combinations of text and symbols for the user interface.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The authoring interface has
+                  been developed to not rely on symbols alone to convey
+                  information to the user.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
+              >
+                1.4.1 Use of Color
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Color is not used without text and often
+                  symbols to convey meaning.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: In general, the admin theme
+                  is very accessible. The Claro Administration Theme shortcut
+                  start needs improvement - Drupal issue 3171726.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
+              >
+                1.4.2 Audio Control
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
+              >
+                2.1.1 Keyboard
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Users can interact with Drupal Core with
+                  the keyboard and without specific timings for individual
+                  keystrokes.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Authors are largely able to
+                  engage with Drupal Core with the keyboard and without specific
+                  timings for individual keystrokes.Tooltips not displayed for
+                  keyboard navigation - Drupal issue 2933984.There are reported
+                  issues with IE11 and JAWS - Drupal issue 2852702.It is worth
+                  noting that Drupal&#x27;s admin is powerful and complex, and
+                  there are other accessibility reports in the issue queue.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
+              >
+                2.1.2 No Keyboard Trap
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Focus can be moved away from that
+                  component using only a keyboard interface.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Focus can be moved away from
+                  that component using only a keyboard interface.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
+              >
+                2.2.1 Pause, Stop, Hide
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: The time limit is longer than 20 hours.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The time limit is longer than
+                  20 hours.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#time-limits-pause">
+                2.2.2 Timing Adjustable
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate">
+                2.3.1 Three Flashes or Below Threshold
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: There are no flashing elements in Drupal
+                  Core.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There are no flashing
+                  elements in Drupal Core.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
+              >
+                2.4.1 Bypass Blocks
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Skip links are provided.</li>
+                <li>
+                  <strong>Electronic Docs</strong>: Skip links are provided.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Skip links are provided.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
+              >
+                2.4.2 Page Titled
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Pages have titles, but in the case of
+                  multi-page events, the page number is not included - Drupal
+                  issue 2509716.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Pages have titles, but in the
+                  case of multi-page events, the page number is not included -
+                  Drupal issue 2509716.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
+              >
+                2.4.3 Focus Order
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Focusable components receive focus in an
+                  order that preserves meaning and operability.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Focusable components receive
+                  focus in an order that preserves meaning and operability.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Focusable components receive
+                  focus in an order that preserves meaning and operability.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
+              >
+                2.4.4 Link Purpose (In Context)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Careful attention has been paid to
+                  ensure that automated &quot;Read More&quot; links are
+                  available in a way that is available with contextual
+                  information for screen readers.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Careful attention has been
+                  paid to ensure that automated &quot;Read More&quot; links are
+                  available in a way that is available with contextual
+                  information for screen readers.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id">
+                3.1.1 Language of Page
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Page language is defined semantically on
+                  every page.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Page language is defined
+                  semantically on every page.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Page language is defined
+                  semantically on every page.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
+              >
+                3.2.1 On Focus
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Change in the focus state does not
+                  initiate a change of context for the user.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Change in the focus state
+                  does not initiate a change of context for the user.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Change in the focus state
+                  does not initiate a change of context for the user.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
+              >
+                3.2.2 On Input
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Engaging with the interactive sites does
+                  not unexpectedly take control from the users.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Engaging with the
+                  interactive sites does not unexpectedly take control from the
+                  users.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Engaging with the interactive
+                  sites does not unexpectedly take control from the users.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified">
+                3.3.1 Error Identification
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: The Inline Form Error module was added
+                  in Drupal 8. This needs to be enabled site-wide on
+                  installation.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The Inline Form Error module
+                  was added in Drupal 8. This needs to be enabled site-wide on
+                  installation.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues">
+                3.3.2 Labels or Instructions
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Default forms all include labels.</li>
+                <li>
+                  <strong>Authoring Tool</strong>: There are a few places where
+                  there are problems with labels, but these are odd exceptions -
+                  Drupal issue 3015494.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses">
+                4.1.1 Parsing
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: There are no HTML5 errors or warnings
+                  that are known to impact assistive technology users.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: There are no HTML5 errors or
+                  warnings that are known to impact assistive technology users.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Generally parsing is very
+                  well supported, but there are a few places where this needs to
+                  be improved - Drupal issue 1852090 and 3144948.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv">
+                4.1.2 Name, Role, Value
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Public pages support this criterion.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Public pages support this
+                  criterion.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: This is generally well
+                  supported, but there are places where it has been overlooked.
+                  Drupal issue 3144948, 3019487, and 3085545.
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Table 2: Success Criteria, Level AA</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
+              >
+                1.2.4 Captions (Live)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
+              >
+                1.2.5 Audio Description (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Does Not Support</li>
+                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Audio files can be uploaded, but there
+                  is no way to associate captions in Core.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: There is no documentation on
+                  how to properly convey pre-recorded audio descriptions.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is no audio in the
+                  authoring interface of Drupal Core, but there is no support
+                  for authors to upload accessible audio files.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
+              >
+                1.4.3 Contrast (Minimum)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Generally meets. Some contrast failures
+                  around grey backgrounds - Drupal issue 3040673.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: The docs have sufficient
+                  contrast.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Generally meets requirements.
+                  Some challenges with Core admin themes - Drupal issue 930508
+                  and 3080100.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
+              >
+                1.4.4 Resize text
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Generally support with some minor
+                  exceptions - Drupal issue 3129257.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: The docs are accessible up
+                  to 200%.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Generally good with some
+                  exceptions - Drupal issue 3164587.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
+              >
+                1.4.5 Images of Text
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Authoring Tool</strong>: Text is generally styled with
+                  CSS in the authoring tool. Should images of text be uploaded
+                  by the user, they will be required to add alternative text.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
+              >
+                2.4.5 Multiple Ways
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: There is more than one way to locate a
+                  Web page within the CMS.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: There is more than one way
+                  to locate a Web page within the CMS.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is more than one way to
+                  locate a Web page within the CMS.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
+              >
+                2.4.6 Headings and Labels
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Generally there is very good support.
+                  Some heading levels may be missed in some unique contexts -
+                  Drupal issue 1768732. Better support could be provided for
+                  threaded comments - Drupal issue 2290043.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Generally good, but for
+                  dynamic elements like the Layout Builder need a plan for a
+                  dynamic heading structure - Drupal issue 3007978.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
+              >
+                2.4.7 Focus Visible
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Focus elements are well established for
+                  the front-end. Further enhancements are being developed to
+                  make it more obvious for keyboard only users.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: An IE specific bug where
+                  there are focus issues for authors and administrators in the
+                  Claro theme - Drupal issue 3048785.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id">
+                3.1.2 Language of Parts
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Multilingual sites have language
+                  switchers with proper semantics. Unfotunately support is
+                  lacking for multi-lingual search 2992894 as well as both the
+                  Filesystem 3163915 &amp; Views components 2496223.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Drupal has good support for
+                  multilingual content and accessibility. To support the
+                  Language of Parts for authors, a button can be added to
+                  simplify the process of adding language specific phrases.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
+              >
+                3.2.3 Consistent Navigation
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Drupal&#x27;s menu structure allows for
+                  consistent navigation across the site.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Drupal&#x27;s menu structure
+                  allows for consistent navigation across the site.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Drupal&#x27;s menu structure
+                  allows for consistent navigation across the site.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
+              >
+                3.2.4 Consistent Identification
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Components in Drupal that have the same
+                  functionality are identified consistently.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Components in Drupal that
+                  have the same functionality are identified consistently.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Components in Drupal that
+                  have the same functionality are identified consistently.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
+              >
+                3.3.3 Error Suggestion
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: The Inline Form Error Module is provided
+                  in Core and needs to be enabled to allow for this
+                  functionality.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: The Inline Form Error Module
+                  is provided in Core and needs to be enabled to allow for this
+                  functionality.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible">
+                3.3.4 Error Prevention (Legal, Financial, Data)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: By default users can editing content
+                  which they own.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Documentation could be
+                  improved.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is nothing to
+                  differentiate editing financial or legal data from any other
+                  data managed by Drupal.
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Table 3: Success Criteria, Level AAA</h3>
+
+      Notes: Where possible the Drupal community strives to exceed AA
+      compliance.
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign">
+                1.2.6 Sign Language (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad">
+                1.2.7 Extended Audio Description (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc">
+                1.2.8 Media Alternative (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only"
+              >
+                1.2.9 Audio-only (Live)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">
+                1.4.6 Contrast (Enhanced)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: A front-end and back-end theme could be
+                  configured to allow this to comply.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio"
+              >
+                1.4.7 Low or No Background Audio
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation"
+              >
+                1.4.8 Visual Presentation
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Evaluated</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Stable Core themes leave much of the
+                  presentation of text to user agents, so aside from line
+                  spacing this generally works.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images"
+              >
+                1.4.9 Images of Text (No Exception)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Text images are all supplied by the
+                  author.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs"
+              >
+                2.1.3 Keyboard (No Exception)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: The web front-end is not a barrier to
+                  keyboard only users.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions">
+                2.2.3 No Timing
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: There are no timeouts in Drupal Core
+                  that would affect people with disabilities.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed">
+                2.2.4 Interruptions
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout"
+              >
+                2.2.5 Re-authenticating
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#seizure-three-times">
+                2.3.2 Three Flashes
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: There is no flashing content.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location"
+              >
+                2.4.8 Location
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Breadcrumbs are available and sitemap
+                  modules can be added to provide additional means for
+                  navigation.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link"
+              >
+                2.4.9 Link Purpose (Link Only)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: There is a mechanism to support
+                  automated links with semantic descriptive titles.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings"
+              >
+                2.4.10 Section Headings
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Drupal provides heading elements at the
+                  beginning of each section of content.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-idioms">
+                3.1.3 Unusual Words
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-located">
+                3.1.4 Abbreviations
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-supplements">
+                3.1.5 Reading Level
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation">
+                3.1.6 Pronunciation
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context"
+              >
+                3.2.5 Change on Request
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help"
+              >
+                3.3.5 Help
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a
+                href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all"
+              >
+                3.3.6 Error Prevention (All)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Revised Section 508 Report</h2>
+      <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
+
+      Notes: Not applicable.
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.1">
+                302.1 Without Vision
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Testing has been done with JAWS, NVDA and VoiceOver.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.2">
+                302.2 With Limited Vision
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Testing has been done with browser zoom and ZoomText.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.3">
+                302.3 Without Perception of Color
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>The interface has been reviewed for use of color.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.4">
+                302.4 Without Hearing
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.5">
+                302.5 With Limited Hearing
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.6">
+                302.6 Without Speech
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.7">
+                302.7 With Limited Manipulation
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Drupal&#x27;s interface does not restrict users with limited
+                  manipulation.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.8">
+                302.8 With Limited Reach and Strength
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Drupal&#x27;s interface does not restrict users with limited
+                  reach or strength.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#302.9">
+                302.9 With Limited Language, Cognitive, and Learning Abilities
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Chapter 4: Hardware</h3>
+
+      Notes: Drupal is a web application. Hardware accessibility criteria is not
+      applicable.
+
+      <h3>Chapter 5: Software</h3>
+
+      Notes: Drupal is a web application. Software accessibility criteria is not
+      applicable.
+
+      <h3>Chapter 6: Support Documentation and Services</h3>
+
+      Notes: Drupal is a web application and all support documentation is
+      delivered through the web. Additional documentation and services are not
+      available.
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#602.2">
+                602.2 Accessibility and Compatibility Features
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#602.4">
+                602.4 Alternate Formats for Non-Electronic Support Documentation
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#603.2">
+                603.2 Information on Accessibility and Compatibility Features
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/#603.3">
+                603.3 Accommodation of Communication Needs
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li>Not Applicable</li>
+              </ul>
+            </td>
+            <td>
+              <ul></ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+    <footer>
+      <h2>Legal Disclaimer</h2>
+      The information herein is provided in good faith based on the analysis of
+      the web application at the time of the review and does not represent a
+      legally-binding claim. Please contact us to report any accessibility
+      errors or conformance claim errors for re-evaluation and correction, if
+      necessary.
+    </footer>
+  </body>
+</html>

--- a/opat/drupal-9.html
+++ b/opat/drupal-9.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Drupal Accessibility Conformance Report</title>
-    <meta name="description" content="Content Management System" />
-  </head>
-  <body>
-    <header>
-      <h1>Drupal Accessibility Conformance Report</h1>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Drupal Accessibility Conformance Report</title>
+  <meta name="description" content="Content Management System">
+</head>
+<body>
+  <header>
+    <h1>Drupal Accessibility Conformance Report</h1>
 
-      Based on VPAT® 2.4 Revised Section 508 Edition
-    </header>
-    <main>
-      <h2>Name of Product/Version</h2>
-      Drupal 9.1
+    Based on VPAT® 2.4 Revised Section 508 Edition
+  </header>
+  <main>
+    <h2>Name of Product/Version</h2>
+    Drupal 9.1
 
-      <h2>Report Date</h2>
-      8/13/2021
+    <h2>Report Date</h2>
+    8/13/2021
 
       <h2>Product Description</h2>
       Content Management System
 
-      <h2>Contact Information</h2>
+    <h2>Contact Information</h2>
       <h3>Author Information</h3>
       <ul>
         <li>Name: Mike Gifford</li>
@@ -35,1970 +35,1531 @@
       </ul>
 
       <h2>Notes</h2>
-      Links to the issues identified are included where possible to ensure that
-      this is a living document where outstanding issues are regularly reviewed
-      for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A
-      and B. Incorporating feedback from the Drupal community.
+      Links to the issues identified are included where possible to ensure that this is a living document where outstanding issues are regularly reviewed for compliance. The Authoring tool is evaluated against ATAG 2.0, Part A and B. Incorporating feedback from the Drupal community.
 
       <h2>Evaluation Methods Used</h2>
-      Use of automated tools like WAVE and Accessibility Insights. Manual
-      keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The
-      evaluation process also includes a review of the Drupal Core accessibility
-      issue queue.
+      Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver. The evaluation process also includes a review of the Drupal Core accessibility issue queue.
 
-      <h2>Applicable Standards/Guidelines</h2>
-      This report covers the degree of conformance for the following
-      accessibility standard/guidelines:
+    <h2>Applicable Standards/Guidelines</h2>
+    This report covers the degree of conformance for the following accessibility standard/guidelines:
 
-      <table>
-        <thead>
+    <table>
+      <thead>
+        <tr>
+          <th>Standard/Guideline</th>
+          <th>Included In Report</th>
+        </tr>
+      </thead>
+      <tbody>
           <tr>
-            <th>Standard/Guideline</th>
-            <th>Included In Report</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/"
-                >Web Content Accessibility Guidelines 2.0</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>Table 1: Success Criteria, Level A</li>
-                <li>Table 2: Success Criteria, Level AA</li>
-                <li>Table 3: Success Criteria, Level AAA</li>
-              </ul>
-            </td>
+            <td><a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a></td>
+            <td><ul><li>Table 1: Success Criteria, Level A</li><li>Table 2: Success Criteria, Level AA</li><li>Table 3: Success Criteria, Level AAA</li></ul></td>
           </tr>
           <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/"
-                >Revised Section 508 standards published January 18, 2017 and
-                corrected January 22, 2018</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>Chapter 3: Functional Performance Criteria (FPC)</li>
-                <li>Chapter 4: Hardware</li>
-                <li>Chapter 5: Software</li>
-                <li>Chapter 6: Support Documentation and Services</li>
-              </ul>
-            </td>
+            <td><a href="https://www.access-board.gov/ict/">Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018</a></td>
+            <td><ul><li>Chapter 3: Functional Performance Criteria (FPC)</li><li>Chapter 4: Hardware</li><li>Chapter 5: Software</li><li>Chapter 6: Support Documentation and Services</li></ul></td>
           </tr>
-        </tbody>
-      </table>
+      </tbody>
+    </table>
 
-      <h2>Terms</h2>
-      The terms used in the Conformance Level information are defined as
-      follows:
-      <ul>
-        <li>
-          <strong>Supports</strong>: The functionality of the product has at
-          least one method that meets the criterion without known defects or
-          meets with equivalent facilitation.
-        </li>
-        <li>
-          <strong>Partially Supports</strong>: Some functionality of the product
-          does not meet the criterion.
-        </li>
-        <li>
-          <strong>Does Not Support</strong>: The majority of product
-          functionality does not meet the criterion.
-        </li>
-        <li>
-          <strong>Not Applicable</strong>: The criterion is not relevant to the
-          product.
-        </li>
-        <li>
-          <strong>Not Evaluated</strong>: The product has not been evaluated
-          against the criterion. This can be used only in WCAG 2.0 Level AAA.
-        </li>
-      </ul>
+    <h2>Terms</h2>
+    The terms used in the Conformance Level information are defined as follows:
+    <ul>
+      <li><strong>Supports</strong>: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.</li>
+      <li><strong>Partially Supports</strong>: Some functionality of the product does not meet the criterion.</li>
+      <li><strong>Does Not Support</strong>: The majority of product functionality does not meet the criterion.</li>
+      <li><strong>Not Applicable</strong>: The criterion is not relevant to the product.</li>
+      <li><strong>Not Evaluated</strong>: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.</li>
+    </ul>
 
       <h2>WCAG 2.0 Report</h2>
-      <h3>Table 1: Success Criteria, Level A</h3>
+          <h3>Table 1: Success Criteria, Level A</h3>
 
-      Notes: Drupal doesn&#x27;t make a strong distinction between the front-end
-      &amp; back-end accessibility. Many administration interfaces can be
-      exposed to users in a more interactive site. Generally this report focuses
-      the Conformance Level / Remarks and Explainations so that Web comments are
-      about elements that are typically public, while Authoring Tool is
-      typically for authors and administrators. The goal of the authoring
-      interface is to support ATAG 2.0 AA (Part A and B). The Drupal community
-      strives to beek up with the latest WCAG recommendation.
+              Notes: Drupal doesn&#x27;t make a strong distinction between the front-end &amp; back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation.
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
-                1.1.1 Non-text Content
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Drupal 8 requires alt text for images by
-                  default.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Some non-textual content in
-                  the documentation does not provide a textual alternative.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The back end of Drupal Core
-                  was built to be WCAG 2.0 AA compliant and non-text content in
-                  the administration interface has a textual equivalent. Audio
-                  and video can be added to the media library, but Core does not
-                  provide tools to manage transcripts and captions/subtitles for
-                  local video and audio - Drupal issue 3002770.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt">
-                1.2.1 Audio-only and Video-only (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Authors can satisfy 1.2.1 Audio-only and
-                  Video-only (Prerecorded) by using text on the same page.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: This is not explicitly
-                  defined in the documentation.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is no additional
-                  support for authors within the authoring interface to explain
-                  how this can be done.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
-                1.2.2 Captions (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Does Not Support</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Does Not Support</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: The file module in Core lets authors
-                  upload audio and video content, and output &lt;audio&gt; and
-                  &lt;video&gt; elements and does not support captions.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Drupal does not support, let
-                  alone require users to include captions. Hard coding open
-                  captions is presently the only way to satisfy this in Core.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">
-                1.2.3 Audio Description or Media Alternative (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Does Not Support</li>
-                <li><strong>Electronic Docs</strong>: Does Not Support</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Does Not Support</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Audio files can be uploaded, but there
-                  is no way to associate captions in Core.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: There is no documentation on
-                  how to properly convey pre-recorded audio descriptions.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is no audio in the
-                  authoring interface of Drupal Core, but there is no support
-                  for authors to upload accessible audio files.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
-              >
-                1.3.1 Info and Relationships
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Information is structured into logical
-                  relationships. Navigational lists are well used to group
-                  information. Forms have a visual and semantic representation
-                  for required fields.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Information is structured
-                  into logical relationships. Navigational lists are well used
-                  to group information.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The authoring environment was
-                  constructed to support ATAG 2.0 AA (Part A and B).
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
-              >
-                1.3.2 Meaningful Sequence
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Drupal Core has been extensively tested
-                  with keyboard only users. As a proudly multilingual CMS,
-                  Drupal provides support for bidirectional navigation.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The authoring environment was
-                  constructed to support ATAG 2.0 AA (Part A and B).
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
-              >
-                1.3.3 Sensory Characteristics
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Where possible Drupal Core uses
-                  combinations of text and symbols for the user interface.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The authoring interface has
-                  been developed to not rely on symbols alone to convey
-                  information to the user.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
-              >
-                1.4.1 Use of Color
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Color is not used without text and often
-                  symbols to convey meaning.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: In general, the admin theme
-                  is very accessible. The Claro Administration Theme shortcut
-                  start needs improvement - Drupal issue 3171726.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
-              >
-                1.4.2 Audio Control
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
-              >
-                2.1.1 Keyboard
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Users can interact with Drupal Core with
-                  the keyboard and without specific timings for individual
-                  keystrokes.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Authors are largely able to
-                  engage with Drupal Core with the keyboard and without specific
-                  timings for individual keystrokes.Tooltips not displayed for
-                  keyboard navigation - Drupal issue 2933984.There are reported
-                  issues with IE11 and JAWS - Drupal issue 2852702.It is worth
-                  noting that Drupal&#x27;s admin is powerful and complex, and
-                  there are other accessibility reports in the issue queue.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
-              >
-                2.1.2 No Keyboard Trap
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Focus can be moved away from that
-                  component using only a keyboard interface.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Focus can be moved away from
-                  that component using only a keyboard interface.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
-              >
-                2.2.1 Pause, Stop, Hide
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: The time limit is longer than 20 hours.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The time limit is longer than
-                  20 hours.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#time-limits-pause">
-                2.2.2 Timing Adjustable
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate">
-                2.3.1 Three Flashes or Below Threshold
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: There are no flashing elements in Drupal
-                  Core.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There are no flashing
-                  elements in Drupal Core.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
-              >
-                2.4.1 Bypass Blocks
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Skip links are provided.</li>
-                <li>
-                  <strong>Electronic Docs</strong>: Skip links are provided.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Skip links are provided.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
-              >
-                2.4.2 Page Titled
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Pages have titles, but in the case of
-                  multi-page events, the page number is not included - Drupal
-                  issue 2509716.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Pages have titles, but in the
-                  case of multi-page events, the page number is not included -
-                  Drupal issue 2509716.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
-              >
-                2.4.3 Focus Order
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Focusable components receive focus in an
-                  order that preserves meaning and operability.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Focusable components receive
-                  focus in an order that preserves meaning and operability.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Focusable components receive
-                  focus in an order that preserves meaning and operability.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
-              >
-                2.4.4 Link Purpose (In Context)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Careful attention has been paid to
-                  ensure that automated &quot;Read More&quot; links are
-                  available in a way that is available with contextual
-                  information for screen readers.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Careful attention has been
-                  paid to ensure that automated &quot;Read More&quot; links are
-                  available in a way that is available with contextual
-                  information for screen readers.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id">
-                3.1.1 Language of Page
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Page language is defined semantically on
-                  every page.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Page language is defined
-                  semantically on every page.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Page language is defined
-                  semantically on every page.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
-              >
-                3.2.1 On Focus
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Change in the focus state does not
-                  initiate a change of context for the user.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Change in the focus state
-                  does not initiate a change of context for the user.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Change in the focus state
-                  does not initiate a change of context for the user.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
-              >
-                3.2.2 On Input
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Engaging with the interactive sites does
-                  not unexpectedly take control from the users.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Engaging with the
-                  interactive sites does not unexpectedly take control from the
-                  users.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Engaging with the interactive
-                  sites does not unexpectedly take control from the users.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified">
-                3.3.1 Error Identification
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: The Inline Form Error module was added
-                  in Drupal 8. This needs to be enabled site-wide on
-                  installation.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The Inline Form Error module
-                  was added in Drupal 8. This needs to be enabled site-wide on
-                  installation.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues">
-                3.3.2 Labels or Instructions
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Default forms all include labels.</li>
-                <li>
-                  <strong>Authoring Tool</strong>: There are a few places where
-                  there are problems with labels, but these are odd exceptions -
-                  Drupal issue 3015494.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses">
-                4.1.1 Parsing
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: There are no HTML5 errors or warnings
-                  that are known to impact assistive technology users.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: There are no HTML5 errors or
-                  warnings that are known to impact assistive technology users.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Generally parsing is very
-                  well supported, but there are a few places where this needs to
-                  be improved - Drupal issue 1852090 and 3144948.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv">
-                4.1.2 Name, Role, Value
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Public pages support this criterion.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Public pages support this
-                  criterion.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: This is generally well
-                  supported, but there are places where it has been overlooked.
-                  Drupal issue 3144948, 3019487, and 3085545.
-                </li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
+                          1.1.1 Non-text Content
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal 8 requires alt text for images by default.</li>
+                              <li><strong>Electronic Docs</strong>: Some non-textual content in the documentation does not provide a textual alternative.</li>
+                              <li><strong>Authoring Tool</strong>: The back end of Drupal Core was built to be  WCAG 2.0 AA compliant and non-text content in the administration interface has a textual equivalent. Audio and video can be added to the media library, but Core does not provide tools to manage transcripts and captions/subtitles for local video and audio - Drupal issue 3002770.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt">
+                          1.2.1 Audio-only and Video-only (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Authors can satisfy 1.2.1 Audio-only and Video-only (Prerecorded) by using text on the same page.</li>
+                              <li><strong>Electronic Docs</strong>: This is not explicitly defined in the documentation.</li>
+                              <li><strong>Authoring Tool</strong>: There is no additional support for authors within the authoring interface to explain how this can be done.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
+                          1.2.2 Captions (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The file module in Core lets authors upload audio and video content, and output &lt;audio&gt; and &lt;video&gt; elements and does not support captions.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal does not support, let alone require users to include captions. Hard coding open captions is presently the only way to satisfy this in Core.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">
+                          1.2.3 Audio Description or Media Alternative (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Audio files can be uploaded, but there is no way to associate captions in Core.</li>
+                              <li><strong>Electronic Docs</strong>: There is no documentation on how to properly convey pre-recorded audio descriptions.</li>
+                              <li><strong>Authoring Tool</strong>: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">
+                          1.3.1 Info and Relationships
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Information is structured into logical relationships. Navigational lists are well used to group information. Forms have a visual and semantic representation for required fields.</li>
+                              <li><strong>Electronic Docs</strong>: Information is structured into logical relationships. Navigational lists are well used to group information.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">
+                          1.3.2 Meaningful Sequence
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal Core has been extensively tested with keyboard only users. As a proudly multilingual CMS, Drupal provides support for bidirectional navigation.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring environment was constructed to support ATAG 2.0 AA (Part A and B).</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding">
+                          1.3.3 Sensory Characteristics
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Where possible Drupal Core uses combinations of text and symbols for the user interface.</li>
+                              <li><strong>Authoring Tool</strong>: The authoring interface has been developed to not rely on symbols alone to convey information to the user.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color">
+                          1.4.1 Use of Color
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Color is not used without text and often symbols to convey meaning.</li>
+                              <li><strong>Authoring Tool</strong>: In general, the admin theme is very accessible. The Claro Administration Theme shortcut start needs improvement - Drupal issue 3171726.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio">
+                          1.4.2 Audio Control
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable">
+                          2.1.1 Keyboard
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Users can interact with Drupal Core with the keyboard and without specific timings for individual keystrokes.</li>
+                              <li><strong>Authoring Tool</strong>: Authors are largely able to engage with Drupal Core with the keyboard and without specific timings for individual keystrokes.Tooltips not displayed for keyboard navigation - Drupal issue 2933984.There are reported issues with IE11 and JAWS - Drupal issue 2852702.It is worth noting that Drupal&#x27;s admin is powerful and complex, and there are other accessibility reports in the issue queue.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping">
+                          2.1.2 No Keyboard Trap
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focus can be moved away from that component using only a keyboard interface.</li>
+                              <li><strong>Authoring Tool</strong>: Focus can be moved away from that component using only a keyboard interface.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors">
+                          2.2.1 Pause, Stop, Hide
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The time limit is longer than 20 hours.</li>
+                              <li><strong>Authoring Tool</strong>: The time limit is longer than 20 hours.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-pause">
+                          2.2.2 Timing Adjustable
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate">
+                          2.3.1 Three Flashes or Below Threshold
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no flashing elements in Drupal Core.</li>
+                              <li><strong>Authoring Tool</strong>: There are no flashing elements in Drupal Core.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip">
+                          2.4.1 Bypass Blocks
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Skip links are provided.</li>
+                              <li><strong>Electronic Docs</strong>: Skip links are provided.</li>
+                              <li><strong>Authoring Tool</strong>: Skip links are provided.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">
+                          2.4.2 Page Titled
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li>
+                              <li><strong>Authoring Tool</strong>: Pages have titles, but in the case of multi-page events, the page number is not included - Drupal issue 2509716.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order">
+                          2.4.3 Focus Order
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                              <li><strong>Electronic Docs</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                              <li><strong>Authoring Tool</strong>: Focusable components receive focus in an order that preserves meaning and operability.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs">
+                          2.4.4 Link Purpose (In Context)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li>
+                              <li><strong>Authoring Tool</strong>: Careful attention has been paid to ensure that automated &quot;Read More&quot; links are available in a way that is available with contextual information for screen readers.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id">
+                          3.1.1 Language of Page
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Page language is defined semantically on every page.</li>
+                              <li><strong>Electronic Docs</strong>: Page language is defined semantically on every page.</li>
+                              <li><strong>Authoring Tool</strong>: Page language is defined semantically on every page.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus">
+                          3.2.1 On Focus
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                              <li><strong>Electronic Docs</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                              <li><strong>Authoring Tool</strong>: Change in the focus state does not initiate a change of context for the user.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change">
+                          3.2.2 On Input
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                              <li><strong>Electronic Docs</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                              <li><strong>Authoring Tool</strong>: Engaging with the interactive sites does not unexpectedly take control from the users.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified">
+                          3.3.1 Error Identification
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li>
+                              <li><strong>Authoring Tool</strong>: The Inline Form Error module was added in Drupal 8. This needs to be enabled site-wide on installation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues">
+                          3.3.2 Labels or Instructions
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Default forms all include labels.</li>
+                              <li><strong>Authoring Tool</strong>: There are a few places where there are problems with labels, but these are odd exceptions - Drupal issue 3015494.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses">
+                          4.1.1 Parsing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li>
+                              <li><strong>Electronic Docs</strong>: There are no HTML5 errors or warnings that are known to impact assistive technology users.</li>
+                              <li><strong>Authoring Tool</strong>: Generally parsing is very well supported, but there are a few places where this needs to be improved - Drupal issue 1852090 and 3144948.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv">
+                          4.1.2 Name, Role, Value
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Public pages support this criterion.</li>
+                              <li><strong>Electronic Docs</strong>: Public pages support this criterion.</li>
+                              <li><strong>Authoring Tool</strong>: This is generally well supported, but there are places where it has been overlooked. Drupal issue 3144948, 3019487, and 3085545.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
 
-      <h3>Table 2: Success Criteria, Level AA</h3>
+          <h3>Table 2: Success Criteria, Level AA</h3>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
-              >
-                1.2.4 Captions (Live)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
-              >
-                1.2.5 Audio Description (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Does Not Support</li>
-                <li><strong>Electronic Docs</strong>: Does Not Support</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Does Not Support</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Audio files can be uploaded, but there
-                  is no way to associate captions in Core.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: There is no documentation on
-                  how to properly convey pre-recorded audio descriptions.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is no audio in the
-                  authoring interface of Drupal Core, but there is no support
-                  for authors to upload accessible audio files.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
-              >
-                1.4.3 Contrast (Minimum)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Generally meets. Some contrast failures
-                  around grey backgrounds - Drupal issue 3040673.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: The docs have sufficient
-                  contrast.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Generally meets requirements.
-                  Some challenges with Core admin themes - Drupal issue 930508
-                  and 3080100.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
-              >
-                1.4.4 Resize text
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Generally support with some minor
-                  exceptions - Drupal issue 3129257.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: The docs are accessible up
-                  to 200%.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Generally good with some
-                  exceptions - Drupal issue 3164587.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
-              >
-                1.4.5 Images of Text
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Authoring Tool</strong>: Text is generally styled with
-                  CSS in the authoring tool. Should images of text be uploaded
-                  by the user, they will be required to add alternative text.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
-              >
-                2.4.5 Multiple Ways
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: There is more than one way to locate a
-                  Web page within the CMS.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: There is more than one way
-                  to locate a Web page within the CMS.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is more than one way to
-                  locate a Web page within the CMS.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
-              >
-                2.4.6 Headings and Labels
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Generally there is very good support.
-                  Some heading levels may be missed in some unique contexts -
-                  Drupal issue 1768732. Better support could be provided for
-                  threaded comments - Drupal issue 2290043.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Generally good, but for
-                  dynamic elements like the Layout Builder need a plan for a
-                  dynamic heading structure - Drupal issue 3007978.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
-              >
-                2.4.7 Focus Visible
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Focus elements are well established for
-                  the front-end. Further enhancements are being developed to
-                  make it more obvious for keyboard only users.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: An IE specific bug where
-                  there are focus issues for authors and administrators in the
-                  Claro theme - Drupal issue 3048785.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id">
-                3.1.2 Language of Parts
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Multilingual sites have language
-                  switchers with proper semantics. Unfotunately support is
-                  lacking for multi-lingual search 2992894 as well as both the
-                  Filesystem 3163915 &amp; Views components 2496223.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Drupal has good support for
-                  multilingual content and accessibility. To support the
-                  Language of Parts for authors, a button can be added to
-                  simplify the process of adding language specific phrases.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
-              >
-                3.2.3 Consistent Navigation
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Drupal&#x27;s menu structure allows for
-                  consistent navigation across the site.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Drupal&#x27;s menu structure
-                  allows for consistent navigation across the site.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Drupal&#x27;s menu structure
-                  allows for consistent navigation across the site.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
-              >
-                3.2.4 Consistent Identification
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Components in Drupal that have the same
-                  functionality are identified consistently.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Components in Drupal that
-                  have the same functionality are identified consistently.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Components in Drupal that
-                  have the same functionality are identified consistently.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
-              >
-                3.3.3 Error Suggestion
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Not Applicable</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: The Inline Form Error Module is provided
-                  in Core and needs to be enabled to allow for this
-                  functionality.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: The Inline Form Error Module
-                  is provided in Core and needs to be enabled to allow for this
-                  functionality.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible">
-                3.3.4 Error Prevention (Legal, Financial, Data)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: By default users can editing content
-                  which they own.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Documentation could be
-                  improved.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is nothing to
-                  differentiate editing financial or legal data from any other
-                  data managed by Drupal.
-                </li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
 
-      <h3>Table 3: Success Criteria, Level AAA</h3>
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions">
+                          1.2.4 Captions (Live)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only">
+                          1.2.5 Audio Description (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Does Not Support</li>
+                                <li><strong>Electronic Docs</strong>: Does Not Support</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Audio files can be uploaded, but there is no way to associate captions in Core.</li>
+                              <li><strong>Electronic Docs</strong>: There is no documentation on how to properly convey pre-recorded audio descriptions.</li>
+                              <li><strong>Authoring Tool</strong>: There is no audio in the authoring interface of Drupal Core, but there is no support for authors to upload accessible audio files.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast">
+                          1.4.3 Contrast (Minimum)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally meets. Some contrast failures around grey backgrounds - Drupal issue 3040673.</li>
+                              <li><strong>Electronic Docs</strong>: The docs have sufficient contrast.</li>
+                              <li><strong>Authoring Tool</strong>: Generally meets requirements. Some challenges with Core admin themes - Drupal issue 930508 and 3080100.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale">
+                          1.4.4 Resize text
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally support with some minor exceptions - Drupal issue 3129257.</li>
+                              <li><strong>Electronic Docs</strong>: The docs are accessible up to 200%.</li>
+                              <li><strong>Authoring Tool</strong>: Generally good with some exceptions - Drupal issue 3164587.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation">
+                          1.4.5 Images of Text
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Authoring Tool</strong>: Text is generally styled with CSS in the authoring tool. Should images of text be uploaded by the user, they will be required to add alternative text.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc">
+                          2.4.5 Multiple Ways
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                              <li><strong>Electronic Docs</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                              <li><strong>Authoring Tool</strong>: There is more than one way to locate a Web page within the CMS.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive">
+                          2.4.6 Headings and Labels
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Generally there is very good support. Some heading levels may be missed in some unique contexts - Drupal issue 1768732. Better support could be provided for threaded comments - Drupal issue 2290043.</li>
+                              <li><strong>Authoring Tool</strong>: Generally good, but for dynamic elements like the Layout Builder need a plan for a dynamic heading structure - Drupal issue 3007978.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible">
+                          2.4.7 Focus Visible
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Focus elements are well established for the front-end. Further enhancements are being developed to make it more obvious for keyboard only users.</li>
+                              <li><strong>Authoring Tool</strong>: An IE specific bug where there are focus issues for authors and administrators in the Claro theme - Drupal issue 3048785.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id">
+                          3.1.2 Language of Parts
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Multilingual sites have language switchers with proper semantics. Unfotunately support is lacking for multi-lingual search 2992894 as well as both the Filesystem 3163915 &amp; Views components 2496223.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal has good support for multilingual content and accessibility. To support the Language of Parts for authors, a button can be added to simplify the process of adding language specific phrases.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations">
+                          3.2.3 Consistent Navigation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                              <li><strong>Electronic Docs</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                              <li><strong>Authoring Tool</strong>: Drupal&#x27;s menu structure allows for consistent navigation across the site.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality">
+                          3.2.4 Consistent Identification
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                              <li><strong>Electronic Docs</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                              <li><strong>Authoring Tool</strong>: Components in Drupal that have the same functionality are identified consistently.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions">
+                          3.3.3 Error Suggestion
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Not Applicable</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li>
+                              <li><strong>Authoring Tool</strong>: The Inline Form Error Module is provided in Core and needs to be enabled to allow for this functionality.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible">
+                          3.3.4 Error Prevention (Legal, Financial, Data)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: By default users can editing content which they own.</li>
+                              <li><strong>Electronic Docs</strong>: Documentation could be improved.</li>
+                              <li><strong>Authoring Tool</strong>: There is nothing to differentiate editing financial or legal data from any other data managed by Drupal.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
 
-      Notes: Where possible the Drupal community strives to exceed AA
-      compliance.
+          <h3>Table 3: Success Criteria, Level AAA</h3>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign">
-                1.2.6 Sign Language (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad">
-                1.2.7 Extended Audio Description (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc">
-                1.2.8 Media Alternative (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only"
-              >
-                1.2.9 Audio-only (Live)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">
-                1.4.6 Contrast (Enhanced)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: A front-end and back-end theme could be
-                  configured to allow this to comply.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio"
-              >
-                1.4.7 Low or No Background Audio
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation"
-              >
-                1.4.8 Visual Presentation
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Evaluated</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Stable Core themes leave much of the
-                  presentation of text to user agents, so aside from line
-                  spacing this generally works.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images"
-              >
-                1.4.9 Images of Text (No Exception)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Text images are all supplied by the
-                  author.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs"
-              >
-                2.1.3 Keyboard (No Exception)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: The web front-end is not a barrier to
-                  keyboard only users.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions">
-                2.2.3 No Timing
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: There are no timeouts in Drupal Core
-                  that would affect people with disabilities.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed">
-                2.2.4 Interruptions
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout"
-              >
-                2.2.5 Re-authenticating
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#seizure-three-times">
-                2.3.2 Three Flashes
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: There is no flashing content.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location"
-              >
-                2.4.8 Location
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Breadcrumbs are available and sitemap
-                  modules can be added to provide additional means for
-                  navigation.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link"
-              >
-                2.4.9 Link Purpose (Link Only)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: There is a mechanism to support
-                  automated links with semantic descriptive titles.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings"
-              >
-                2.4.10 Section Headings
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Drupal provides heading elements at the
-                  beginning of each section of content.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-idioms">
-                3.1.3 Unusual Words
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-located">
-                3.1.4 Abbreviations
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-supplements">
-                3.1.5 Reading Level
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation">
-                3.1.6 Pronunciation
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context"
-              >
-                3.2.5 Change on Request
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help"
-              >
-                3.3.5 Help
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a
-                href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all"
-              >
-                3.3.6 Error Prevention (All)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              Notes: Where possible the Drupal community strives to exceed AA compliance.
+
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign">
+                          1.2.6 Sign Language (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad">
+                          1.2.7 Extended Audio Description (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc">
+                          1.2.8 Media Alternative (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only">
+                          1.2.9 Audio-only (Live)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7">
+                          1.4.6 Contrast (Enhanced)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: A front-end and back-end theme could be configured to allow this to comply.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio">
+                          1.4.7 Low or No Background Audio
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation">
+                          1.4.8 Visual Presentation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Evaluated</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Stable Core themes leave much of the presentation of text to user agents, so aside from line spacing this generally works.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images">
+                          1.4.9 Images of Text (No Exception)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Text images are all supplied by the author.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs">
+                          2.1.3 Keyboard (No Exception)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: The web front-end is not a barrier to keyboard only users.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions">
+                          2.2.3 No Timing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There are no timeouts in Drupal Core that would affect people with disabilities.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed">
+                          2.2.4 Interruptions
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout">
+                          2.2.5 Re-authenticating
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#seizure-three-times">
+                          2.3.2 Three Flashes
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is no flashing content.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location">
+                          2.4.8 Location
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Breadcrumbs are available and sitemap modules can be added to provide additional means for navigation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link">
+                          2.4.9 Link Purpose (Link Only)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: There is a mechanism to support automated links with semantic descriptive titles.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings">
+                          2.4.10 Section Headings
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Drupal provides heading elements at the beginning of each section of content.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-idioms">
+                          3.1.3 Unusual Words
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-located">
+                          3.1.4 Abbreviations
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-supplements">
+                          3.1.5 Reading Level
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation">
+                          3.1.6 Pronunciation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context">
+                          3.2.5 Change on Request
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help">
+                          3.3.5 Help
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all">
+                          3.3.6 Error Prevention (All)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
 
       <h2>Revised Section 508 Report</h2>
-      <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
+          <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
 
-      Notes: Not applicable.
+              Notes: Not applicable.
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.1">
-                302.1 Without Vision
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>Testing has been done with JAWS, NVDA and VoiceOver.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.2">
-                302.2 With Limited Vision
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>Testing has been done with browser zoom and ZoomText.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.3">
-                302.3 Without Perception of Color
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>The interface has been reviewed for use of color.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.4">
-                302.4 Without Hearing
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.5">
-                302.5 With Limited Hearing
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.6">
-                302.6 Without Speech
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.7">
-                302.7 With Limited Manipulation
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  Drupal&#x27;s interface does not restrict users with limited
-                  manipulation.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.8">
-                302.8 With Limited Reach and Strength
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  Drupal&#x27;s interface does not restrict users with limited
-                  reach or strength.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#302.9">
-                302.9 With Limited Language, Cognitive, and Learning Abilities
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.1">
+                          302.1 Without Vision
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Testing has been done with JAWS, NVDA and VoiceOver.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.2">
+                          302.2 With Limited Vision
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Testing has been done with browser zoom and ZoomText.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.3">
+                          302.3 Without Perception of Color
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>The interface has been reviewed for use of color.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.4">
+                          302.4 Without Hearing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.5">
+                          302.5 With Limited Hearing
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.6">
+                          302.6 Without Speech
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.7">
+                          302.7 With Limited Manipulation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Drupal&#x27;s interface does not restrict users with limited manipulation.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.8">
+                          302.8 With Limited Reach and Strength
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li>Drupal&#x27;s interface does not restrict users with limited reach or strength.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#302.9">
+                          302.9 With Limited Language, Cognitive, and Learning Abilities
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
 
-      <h3>Chapter 4: Hardware</h3>
+          <h3>Chapter 4: Hardware</h3>
 
-      Notes: Drupal is a web application. Hardware accessibility criteria is not
-      applicable.
+              Notes: Drupal is a web application. Hardware accessibility criteria is not applicable.
 
-      <h3>Chapter 5: Software</h3>
+          <h3>Chapter 5: Software</h3>
 
-      Notes: Drupal is a web application. Software accessibility criteria is not
-      applicable.
+              Notes: Drupal is a web application. Software accessibility criteria is not applicable.
 
-      <h3>Chapter 6: Support Documentation and Services</h3>
+          <h3>Chapter 6: Support Documentation and Services</h3>
 
-      Notes: Drupal is a web application and all support documentation is
-      delivered through the web. Additional documentation and services are not
-      available.
+              Notes: Drupal is a web application and all support documentation is delivered through the web. Additional documentation and services are not available.
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#602.2">
-                602.2 Accessibility and Compatibility Features
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#602.4">
-                602.4 Alternate Formats for Non-Electronic Support Documentation
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#603.2">
-                603.2 Information on Accessibility and Compatibility Features
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/#603.3">
-                603.3 Accommodation of Communication Needs
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li>Not Applicable</li>
-              </ul>
-            </td>
-            <td>
-              <ul></ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </main>
-    <footer>
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#602.2">
+                          602.2 Accessibility and Compatibility Features
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#602.4">
+                          602.4 Alternate Formats for Non-Electronic Support Documentation
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#603.2">
+                          603.2 Information on Accessibility and Compatibility Features
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.access-board.gov/ict/#603.3">
+                          603.3 Accommodation of Communication Needs
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li>Not Applicable</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
+
+  </main>
+  <footer>
       <h2>Legal Disclaimer</h2>
-      The information herein is provided in good faith based on the analysis of
-      the web application at the time of the review and does not represent a
-      legally-binding claim. Please contact us to report any accessibility
-      errors or conformance claim errors for re-evaluation and correction, if
-      necessary.
-    </footer>
-  </body>
+      The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
+  </footer>
+</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "lint": "eslint . --ext .ts",
     "generate-example-output": "npx ts-node src/opat.ts output -f tests/examples/valid.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o tests/examples/valid.markdown",
     "generate-drupal-output": "npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o opat/drupal-9.markdown",
+    "generate-example-html": "npx ts-node src/opat.ts output -f tests/examples/valid.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o tests/examples/valid.html",
+    "generate-drupal-html": "npx ts-node src/opat.ts output -f opat/drupal-9.yaml -c catalog/2.4-edition-wcag-2.0-508-en.yaml -o opat/drupal-9.html",
     "generate-508-catalog": "npx ts-node src/librarian.ts -c 508"
   }
 }

--- a/src/opat.ts
+++ b/src/opat.ts
@@ -86,7 +86,17 @@ if (fs.existsSync(argv.file)) {
     // Output OPAT as markdown if command is set to 'output' and is valid.
     if (argv._.includes("output") && result.result) {
       const outputFile = argv.outputFile ?? "output/opat.markdown";
-      result = outputOPAT(data, catalog, outputFile);
+      const fileExt = outputFile.split(".").pop();
+      if (fileExt === "html") {
+        result = outputOPAT(
+          data,
+          catalog,
+          outputFile,
+          "templates/opat-html-0.1.0.handlebars"
+        );
+      } else {
+        result = outputOPAT(data, catalog, outputFile);
+      }
     }
   } catch {
     result = {

--- a/src/outputOPAT.ts
+++ b/src/outputOPAT.ts
@@ -64,7 +64,14 @@ export function outputOPAT(
         for (const component of catalogData.components) {
           if (component.id === componentId) {
             if (component.label != "") {
-              return "**" + component.label + "**: ";
+              const fileExt = outputFile.split(".").pop();
+              if (fileExt === "html") {
+                return new Handlebars.SafeString(
+                  `<strong>${component.label}</strong>: `
+                );
+              } else {
+                return `**${component.label}**: `;
+              }
             }
           }
         }

--- a/templates/opat-html-0.1.0.handlebars
+++ b/templates/opat-html-0.1.0.handlebars
@@ -10,145 +10,151 @@
 {{/if}}
 </head>
 <body>
-  <h1>{{title}}</h1>
+  <header>
+    <h1>{{title}}</h1>
 
-  Based on {{catalog.title}}
+    Based on {{catalog.title}}
+  </header>
+  <main>
+    <h2>Name of Product/Version</h2>
+    {{product.name}}{{#if product.version}} {{product.version}}{{/if}}
 
-  <h2>Name of Product/Version</h2>
-  {{product.name}}{{#if product.version}} {{product.version}}{{/if}}
+    <h2>Report Date</h2>
+    {{ now }}
 
-  <h2>Report Date</h2>
-  {{ now }}
+    {{#if product.description}}
+      <h2>Product Description</h2>
+      {{product.description}}
+    {{/if}}
 
-  {{#if product.description}}
-    <h2>Product Description</h2>
-    {{product.description}}
-  {{/if}}
+    <h2>Contact Information</h2>
+    {{#if author}}
+      <h3>Author Information</h3>
+      <ul>
+        {{#if author.name}}<li>Name: {{author.name}}</li>{{/if}}
+        {{#if author.company_name}}<li>Company: {{author.company_name}}</li>{{/if}}
+        {{#if author.address}}<li>Address: {{author.address}}</li>{{/if}}
+        {{#if author.email}}<li>Email: {{author.email}}</li>{{/if}}
+        {{#if author.phone}}<li>Phone: {{author.phone}}</li>{{/if}}
+        {{#if author.website}}<li>Website: {{author.website}}</li>{{/if}}
+      </ul>
+    {{/if}}
+    {{#if vendor}}
+      <h3>Vendor Information</h3>
+      <ul>
+      {{#if vendor.name}}<li>Name: {{vendor.name}}</li>{{/if}}
+      {{#if vendor.company_name}}<li>Company: {{vendor.company_name}}</li>{{/if}}
+      {{#if vendor.address}}<li>Address: {{vendor.address}}</li>{{/if}}
+      {{#if vendor.email}}<li>Email: {{vendor.email}}</li>{{/if}}
+      {{#if vendor.phone}}<li>Phone: {{vendor.phone}}</li>{{/if}}
+      {{#if vendor.website}}<li>Website: {{vendor.website}}</li>{{/if}}
+      </ul>
+    {{/if}}
 
-  <h2>Contact Information</h2>
-  {{#if author}}
-    <h3>Author Information</h3>
-    <ul>
-      {{#if author.name}}<li>Name: {{author.name}}</li>{{/if}}
-      {{#if author.company_name}}<li>Company: {{author.company_name}}</li>{{/if}}
-      {{#if author.address}}<li>Address: {{author.address}}</li>{{/if}}
-      {{#if author.email}}<li>Email: {{author.email}}</li>{{/if}}
-      {{#if author.phone}}<li>Phone: {{author.phone}}</li>{{/if}}
-      {{#if author.website}}<li>Website: {{author.website}}</li>{{/if}}
-    </ul>
-  {{/if}}
-  {{#if vendor}}
-    <h3>Vendor Information</h3>
-    <ul>
-    {{#if vendor.name}}<li>Name: {{vendor.name}}</li>{{/if}}
-    {{#if vendor.company_name}}<li>Company: {{vendor.company_name}}</li>{{/if}}
-    {{#if vendor.address}}<li>Address: {{vendor.address}}</li>{{/if}}
-    {{#if vendor.email}}<li>Email: {{vendor.email}}</li>{{/if}}
-    {{#if vendor.phone}}<li>Phone: {{vendor.phone}}</li>{{/if}}
-    {{#if vendor.website}}<li>Website: {{vendor.website}}</li>{{/if}}
-    </ul>
-  {{/if}}
+    {{#if notes}}
+      <h2>Notes</h2>
+      {{notes}}
+    {{/if}}
 
-  {{#if notes}}
-    <h2>Notes</h2>
-    {{notes}}
-  {{/if}}
+    {{#if evaluation_methods_used}}
+      <h2>Evaluation Methods Used</h2>
+      {{evaluation_methods_used}}
+    {{/if}}
 
-  {{#if evaluation_methods_used}}
-    <h2>Evaluation Methods Used</h2>
-    {{evaluation_methods_used}}
-  {{/if}}
+    <h2>Applicable Standards/Guidelines</h2>
+    This report covers the degree of conformance for the following accessibility standard/guidelines:
 
-  <h2>Applicable Standards/Guidelines</h2>
-  This report covers the degree of conformance for the following accessibility standard/guidelines:
-
-  <table>
-    <thead>
-      <tr>
-        <th>Standard/Guideline</th>
-        <th>Included In Report</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each catalog.standards as |catalog-standard|}}
+    <table>
+      <thead>
         <tr>
-          <td>[{{catalog-standard.label}}]({{catalog-standard.url}})</td>
-          <td>{{standardsIncluded catalog-standard.chapters}}</td>
+          <th>Standard/Guideline</th>
+          <th>Included In Report</th>
         </tr>
-      {{/each}}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {{#each catalog.standards as |catalog-standard|}}
+          <tr>
+            <td><a href="{{catalog-standard.url}}">{{catalog-standard.label}}</a></td>
+            <td>{{standardsIncluded catalog-standard.chapters}}</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
 
-  <h2>Terms</h2>
-  The terms used in the Conformance Level information are defined as follows:
-  <ul>
-  {{#each catalog.terms as |catalog-term|}}
-    <li><strong>{{catalog-term.label}}</strong>: {{catalog-term.description}}</li>
-  {{/each}}
-  </ul>
-
-  {{#each catalog.standards as |catalog-standard|}}
-    <h2>{{catalog-standard.report_heading}}</h2>
-    {{#each catalog-standard.chapters as |catalog-standard-chapter|}}
-      {{#with (catalogChapter catalog-standard-chapter) as |catalog-chapter|}}
-        <h3>{{catalog-chapter.label}}</h3>
-
-        {{#with (lookup ../../../chapters catalog-chapter.id) as |data-category|}}
-          {{#if data-category.notes}}
-            Notes: {{data-category.notes}}
-          {{/if}}
-
-          {{#if data-category.criteria}}
-            <table>
-              <thead>
-              <tr>
-                <th>Criteria</th>
-                <th>Conformance Level</th>
-                <th>Remarks and Explanations</th>
-              </tr>
-              </thead>
-              <tbody>
-                {{#each data-category.criteria as |data-criteria|}}
-                  <tr>
-                    <td>
-                      [{{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}]({{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}})
-                    </td>
-                    <td>
-                      {{#if data-criteria.components}}
-                        <ul>
-                          {{#each data-criteria.components as |data-components|}}
-                            {{#if data-components.adherence.level}}
-                              <li>{{catalogComponentLabel data-components.name}}{{levelLabel data-components.adherence.level}}</li>
-                            {{/if}}
-                          {{/each}}
-                        </ul>
-                      {{/if}}
-                    </td>
-                    <td>
-                      {{#if data-criteria.components}}
-                        <ul>
-                          {{#each data-criteria.components as |data-components|}}
-                            {{#if data-components.adherence.notes}}
-                            <li>{{catalogComponentLabel data-components.name}}{{data-components.adherence.notes}}</li>
-                            {{/if}}
-                          {{/each}}
-                        </ul>
-                      {{/if}}
-                    </td>
-                  </tr>
-                {{/each}}
-              </tbody>
-            </table>
-
-          {{/if}}
-        {{/with}}
-      {{/with}}
+    <h2>Terms</h2>
+    The terms used in the Conformance Level information are defined as follows:
+    <ul>
+    {{#each catalog.terms as |catalog-term|}}
+      <li><strong>{{catalog-term.label}}</strong>: {{catalog-term.description}}</li>
     {{/each}}
-  {{/each}}
+    </ul>
 
-  {{#if legal_disclaimer}}
-    <h2>Legal Disclaimer{{#if vendor.company_name}} ({{vendor.company_name}}){{/if}}</h2>
-    {{legal_disclaimer}}
-  {{/if}}
+    {{#each catalog.standards as |catalog-standard|}}
+      <h2>{{catalog-standard.report_heading}}</h2>
+      {{#each catalog-standard.chapters as |catalog-standard-chapter|}}
+        {{#with (catalogChapter catalog-standard-chapter) as |catalog-chapter|}}
+          <h3>{{catalog-chapter.label}}</h3>
+
+          {{#with (lookup ../../../chapters catalog-chapter.id) as |data-category|}}
+            {{#if data-category.notes}}
+              Notes: {{data-category.notes}}
+            {{/if}}
+
+            {{#if data-category.criteria}}
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                  {{#each data-category.criteria as |data-criteria|}}
+                    <tr>
+                      <td>
+                        <a href="{{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}}">
+                          {{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}
+                        </a>
+                      </td>
+                      <td>
+                        {{#if data-criteria.components}}
+                          <ul>
+                            {{#each data-criteria.components as |data-components|}}
+                              {{#if data-components.adherence.level}}
+                                <li>{{catalogComponentLabel data-components.name}}{{levelLabel data-components.adherence.level}}</li>
+                              {{/if}}
+                            {{/each}}
+                          </ul>
+                        {{/if}}
+                      </td>
+                      <td>
+                        {{#if data-criteria.components}}
+                          <ul>
+                            {{#each data-criteria.components as |data-components|}}
+                              {{#if data-components.adherence.notes}}
+                              <li>{{catalogComponentLabel data-components.name}}{{data-components.adherence.notes}}</li>
+                              {{/if}}
+                            {{/each}}
+                          </ul>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+
+            {{/if}}
+          {{/with}}
+        {{/with}}
+      {{/each}}
+    {{/each}}
+  </main>
+  <footer>
+    {{#if legal_disclaimer}}
+      <h2>Legal Disclaimer{{#if vendor.company_name}} ({{vendor.company_name}}){{/if}}</h2>
+      {{legal_disclaimer}}
+    {{/if}}
+  </footer>
 </body>
 </html>

--- a/templates/opat-html-0.1.0.handlebars
+++ b/templates/opat-html-0.1.0.handlebars
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="{{catalog.lang}}">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{{title}}</title>
+{{#if product.description}}
+  <meta name="description" content="{{product.description}}">
+{{/if}}
+</head>
+<body>
+  <h1>{{title}}</h1>
+
+  Based on {{catalog.title}}
+
+  <h2>Name of Product/Version</h2>
+  {{product.name}}{{#if product.version}} {{product.version}}{{/if}}
+
+  <h2>Report Date</h2>
+  {{ now }}
+
+  {{#if product.description}}
+    <h2>Product Description</h2>
+    {{product.description}}
+  {{/if}}
+
+  <h2>Contact Information</h2>
+  {{#if author}}
+    <h3>Author Information</h3>
+    {{#if author.name}}- Name: {{author.name}}{{/if}}
+    {{#if author.company_name}}- Company: {{author.company_name}}{{/if}}
+    {{#if author.address}}- Address: {{author.address}}{{/if}}
+    {{#if author.email}}- Email: {{author.email}}{{/if}}
+    {{#if author.phone}}- Phone: {{author.phone}}{{/if}}
+    {{#if author.website}}- Website: {{author.website}}{{/if}}
+  {{/if}}
+  {{#if vendor}}
+    <h3>Vendor Information</h3>
+    {{#if vendor.name}}- Name: {{vendor.name}}{{/if}}
+    {{#if vendor.company_name}}- Company: {{vendor.company_name}}{{/if}}
+    {{#if vendor.address}}- Address: {{vendor.address}}{{/if}}
+    {{#if vendor.email}}- Email: {{vendor.email}}{{/if}}
+    {{#if vendor.phone}}- Phone: {{vendor.phone}}{{/if}}
+    {{#if vendor.website}}- Website: {{vendor.website}}{{/if}}
+  {{/if}}
+
+  {{#if notes}}
+    <h2>Notes</h2>
+    {{notes}}
+  {{/if}}
+
+  {{#if evaluation_methods_used}}
+    <h2>Evaluation Methods Used</h2>
+    {{evaluation_methods_used}}
+  {{/if}}
+
+  <h2>Applicable Standards/Guidelines</h2>
+  This report covers the degree of conformance for the following accessibility standard/guidelines:
+
+  | Standard/Guideline | Included In Report |
+  | --- | --- |
+  {{#each catalog.standards as |catalog-standard|}}
+    | [{{catalog-standard.label}}]({{catalog-standard.url}}) | {{standardsIncluded catalog-standard.chapters}} |
+  {{/each}}
+
+  <h2>Terms</h2>
+  The terms used in the Conformance Level information are defined as follows:
+  {{#each catalog.terms as |catalog-term|}}
+    - **{{catalog-term.label}}**: {{catalog-term.description}}
+  {{/each}}
+
+  {{#each catalog.standards as |catalog-standard|}}
+    <h2>{{catalog-standard.report_heading}}</h2>
+    {{#each catalog-standard.chapters as |catalog-standard-chapter|}}
+      {{#with (catalogChapter catalog-standard-chapter) as |catalog-chapter|}}
+        <h3>{{catalog-chapter.label}}</h3>
+
+        {{#with (lookup ../../../chapters catalog-chapter.id) as |data-category|}}
+          {{#if data-category.notes}}
+            Notes: {{data-category.notes}}
+          {{/if}}
+
+          {{#if data-category.criteria}}
+            | Criteria | Conformance Level | Remarks and Explanations |
+            | --- | --- | --- |
+            {{#each data-category.criteria as |data-criteria|}}
+              | [{{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}]({{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}}) | {{#if data-criteria.components}}<ul>{{#each data-criteria.components as |data-components|}}{{#if data-components.adherence.level}}<li>{{catalogComponentLabel data-components.name}}{{levelLabel data-components.adherence.level}}</li>{{/if}}{{/each}} </ul>{{/if}} | {{#if data-criteria.components}}<ul>{{#each data-criteria.components as |data-components|}}{{#if data-components.adherence.notes}}<li>{{catalogComponentLabel data-components.name}}{{data-components.adherence.notes}}</li>{{/if}}{{/each}} </ul>{{/if}} |
+            {{/each}}
+
+          {{/if}}
+        {{/with}}
+      {{/with}}
+    {{/each}}
+  {{/each}}
+
+  {{#if legal_disclaimer}}
+    <h2>Legal Disclaimer{{#if vendor.company_name}} ({{vendor.company_name}}){{/if}}</h2>
+    {{legal_disclaimer}}
+  {{/if}}
+</body>
+</html>

--- a/templates/opat-html-0.1.0.handlebars
+++ b/templates/opat-html-0.1.0.handlebars
@@ -28,21 +28,25 @@
   <h2>Contact Information</h2>
   {{#if author}}
     <h3>Author Information</h3>
-    {{#if author.name}}- Name: {{author.name}}{{/if}}
-    {{#if author.company_name}}- Company: {{author.company_name}}{{/if}}
-    {{#if author.address}}- Address: {{author.address}}{{/if}}
-    {{#if author.email}}- Email: {{author.email}}{{/if}}
-    {{#if author.phone}}- Phone: {{author.phone}}{{/if}}
-    {{#if author.website}}- Website: {{author.website}}{{/if}}
+    <ul>
+      {{#if author.name}}<li>Name: {{author.name}}</li>{{/if}}
+      {{#if author.company_name}}<li>Company: {{author.company_name}}</li>{{/if}}
+      {{#if author.address}}<li>Address: {{author.address}}</li>{{/if}}
+      {{#if author.email}}<li>Email: {{author.email}}</li>{{/if}}
+      {{#if author.phone}}<li>Phone: {{author.phone}}</li>{{/if}}
+      {{#if author.website}}<li>Website: {{author.website}}</li>{{/if}}
+    </ul>
   {{/if}}
   {{#if vendor}}
     <h3>Vendor Information</h3>
-    {{#if vendor.name}}- Name: {{vendor.name}}{{/if}}
-    {{#if vendor.company_name}}- Company: {{vendor.company_name}}{{/if}}
-    {{#if vendor.address}}- Address: {{vendor.address}}{{/if}}
-    {{#if vendor.email}}- Email: {{vendor.email}}{{/if}}
-    {{#if vendor.phone}}- Phone: {{vendor.phone}}{{/if}}
-    {{#if vendor.website}}- Website: {{vendor.website}}{{/if}}
+    <ul>
+    {{#if vendor.name}}<li>Name: {{vendor.name}}</li>{{/if}}
+    {{#if vendor.company_name}}<li>Company: {{vendor.company_name}}</li>{{/if}}
+    {{#if vendor.address}}<li>Address: {{vendor.address}}</li>{{/if}}
+    {{#if vendor.email}}<li>Email: {{vendor.email}}</li>{{/if}}
+    {{#if vendor.phone}}<li>Phone: {{vendor.phone}}</li>{{/if}}
+    {{#if vendor.website}}<li>Website: {{vendor.website}}</li>{{/if}}
+    </ul>
   {{/if}}
 
   {{#if notes}}
@@ -58,17 +62,30 @@
   <h2>Applicable Standards/Guidelines</h2>
   This report covers the degree of conformance for the following accessibility standard/guidelines:
 
-  | Standard/Guideline | Included In Report |
-  | --- | --- |
-  {{#each catalog.standards as |catalog-standard|}}
-    | [{{catalog-standard.label}}]({{catalog-standard.url}}) | {{standardsIncluded catalog-standard.chapters}} |
-  {{/each}}
+  <table>
+    <thead>
+      <tr>
+        <th>Standard/Guideline</th>
+        <th>Included In Report</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each catalog.standards as |catalog-standard|}}
+        <tr>
+          <td>[{{catalog-standard.label}}]({{catalog-standard.url}})</td>
+          <td>{{standardsIncluded catalog-standard.chapters}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
 
   <h2>Terms</h2>
   The terms used in the Conformance Level information are defined as follows:
+  <ul>
   {{#each catalog.terms as |catalog-term|}}
-    - **{{catalog-term.label}}**: {{catalog-term.description}}
+    <li><strong>{{catalog-term.label}}</strong>: {{catalog-term.description}}</li>
   {{/each}}
+  </ul>
 
   {{#each catalog.standards as |catalog-standard|}}
     <h2>{{catalog-standard.report_heading}}</h2>
@@ -82,11 +99,46 @@
           {{/if}}
 
           {{#if data-category.criteria}}
-            | Criteria | Conformance Level | Remarks and Explanations |
-            | --- | --- | --- |
-            {{#each data-category.criteria as |data-criteria|}}
-              | [{{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}]({{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}}) | {{#if data-criteria.components}}<ul>{{#each data-criteria.components as |data-components|}}{{#if data-components.adherence.level}}<li>{{catalogComponentLabel data-components.name}}{{levelLabel data-components.adherence.level}}</li>{{/if}}{{/each}} </ul>{{/if}} | {{#if data-criteria.components}}<ul>{{#each data-criteria.components as |data-components|}}{{#if data-components.adherence.notes}}<li>{{catalogComponentLabel data-components.name}}{{data-components.adherence.notes}}</li>{{/if}}{{/each}} </ul>{{/if}} |
-            {{/each}}
+            <table>
+              <thead>
+              <tr>
+                <th>Criteria</th>
+                <th>Conformance Level</th>
+                <th>Remarks and Explanations</th>
+              </tr>
+              </thead>
+              <tbody>
+                {{#each data-category.criteria as |data-criteria|}}
+                  <tr>
+                    <td>
+                      [{{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}]({{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}})
+                    </td>
+                    <td>
+                      {{#if data-criteria.components}}
+                        <ul>
+                          {{#each data-criteria.components as |data-components|}}
+                            {{#if data-components.adherence.level}}
+                              <li>{{catalogComponentLabel data-components.name}}{{levelLabel data-components.adherence.level}}</li>
+                            {{/if}}
+                          {{/each}}
+                        </ul>
+                      {{/if}}
+                    </td>
+                    <td>
+                      {{#if data-criteria.components}}
+                        <ul>
+                          {{#each data-criteria.components as |data-components|}}
+                            {{#if data-components.adherence.notes}}
+                            <li>{{catalogComponentLabel data-components.name}}{{data-components.adherence.notes}}</li>
+                            {{/if}}
+                          {{/each}}
+                        </ul>
+                      {{/if}}
+                    </td>
+                  </tr>
+                {{/each}}
+              </tbody>
+            </table>
 
           {{/if}}
         {{/with}}

--- a/tests/examples/valid.html
+++ b/tests/examples/valid.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Lorem Ipsum Accessibility Conformance Report</title>
+    <meta name="description" content="Fake text" />
+  </head>
+  <body>
+    <header>
+      <h1>Lorem Ipsum Accessibility Conformance Report</h1>
+
+      Based on VPAT® 2.4 Revised Section 508 Edition
+    </header>
+    <main>
+      <h2>Name of Product/Version</h2>
+      Lorem Ipsum 1.1
+
+      <h2>Report Date</h2>
+      8/13/2021
+
+      <h2>Product Description</h2>
+      Fake text
+
+      <h2>Contact Information</h2>
+      <h3>Author Information</h3>
+      <ul>
+        <li>Name: Cicero</li>
+        <li>Company: Fake text Inc.</li>
+        <li>Address: Rome</li>
+        <li>Email: cicero@example.com</li>
+
+        <li>Website: https://en.wikipedia.org/wiki/Lorem_ipsum</li>
+      </ul>
+      <h3>Vendor Information</h3>
+      <ul>
+        <li>Company: Fake text Inc.</li>
+
+        <li>Email: contact@example.com</li>
+      </ul>
+
+      <h2>Notes</h2>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet
+      viverra lorem. Nullam laoreet vitae lorem et semper. Donec feugiat rutrum
+      luctus. Nunc nec scelerisque orci. Mauris non tellus congue, vestibulum
+      felis at, consectetur dui. Aenean luctus dictum diam. Vestibulum vehicula
+      leo nulla, nec hendrerit felis sodales a. In hac habitasse platea
+      dictumst. Phasellus odio felis, efficitur a mattis vitae, fermentum vitae
+      libero. Nam ut magna id sem pellentesque ultrices. Nulla sed urna vel
+      tortor vehicula varius. Sed scelerisque porta nisi, sit amet ultricies
+      ante ullamcorper quis.
+
+      <h2>Evaluation Methods Used</h2>
+      Use of automated tools like WAVE and Accessibility Insights. Manual
+      keyboard only testing. Some testing with JAWS, NVDA and VoiceOver.
+
+      <h2>Applicable Standards/Guidelines</h2>
+      This report covers the degree of conformance for the following
+      accessibility standard/guidelines:
+
+      <table>
+        <thead>
+          <tr>
+            <th>Standard/Guideline</th>
+            <th>Included In Report</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/"
+                >Web Content Accessibility Guidelines 2.0</a
+              >
+            </td>
+            <td>
+              <ul>
+                <li>Table 1: Success Criteria, Level A</li>
+                <li>Table 2: Success Criteria, Level AA</li>
+                <li>Table 3: Success Criteria, Level AAA</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.access-board.gov/ict/"
+                >Revised Section 508 standards published January 18, 2017 and
+                corrected January 22, 2018</a
+              >
+            </td>
+            <td>
+              <ul>
+                <li>Chapter 3: Functional Performance Criteria (FPC)</li>
+                <li>Chapter 4: Hardware</li>
+                <li>Chapter 5: Software</li>
+                <li>Chapter 6: Support Documentation and Services</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Terms</h2>
+      The terms used in the Conformance Level information are defined as
+      follows:
+      <ul>
+        <li>
+          <strong>Supports</strong>: The functionality of the product has at
+          least one method that meets the criterion without known defects or
+          meets with equivalent facilitation.
+        </li>
+        <li>
+          <strong>Partially Supports</strong>: Some functionality of the product
+          does not meet the criterion.
+        </li>
+        <li>
+          <strong>Does Not Support</strong>: The majority of product
+          functionality does not meet the criterion.
+        </li>
+        <li>
+          <strong>Not Applicable</strong>: The criterion is not relevant to the
+          product.
+        </li>
+        <li>
+          <strong>Not Evaluated</strong>: The product has not been evaluated
+          against the criterion. This can be used only in WCAG 2.0 Level AAA.
+        </li>
+      </ul>
+
+      <h2>WCAG 2.0 Report</h2>
+      <h3>Table 1: Success Criteria, Level A</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Conformance Level</th>
+            <th>Remarks and Explanations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
+                1.1.1 Non-text Content
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Supports</li>
+                <li><strong>Electronic Docs</strong>: Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Supports</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Cras ultrices, diam in laoreet
+                  condimentum, purus leo tempor erat, eu facilisis erat tortor
+                  at purus.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Curabitur tristique tellus
+                  quis ligula elementum, sit amet tincidunt est aliquet.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: Vestibulum sit amet tortor ac
+                  nunc rutrum consequat vel sit amet risus. Nam eget mollis
+                  odio, sit amet bibendum mi. Quisque ac neque a nulla dapibus
+                  imperdiet.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
+                1.2.2 Captions (Prerecorded)
+              </a>
+            </td>
+            <td>
+              <ul>
+                <li><strong>Web</strong>: Partially Supports</li>
+                <li><strong>Electronic Docs</strong>: Partially Supports</li>
+                <li><strong>Software</strong>: Not Applicable</li>
+                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  <strong>Web</strong>: Nam a cursus nulla. Vestibulum tincidunt
+                  tincidunt volutpat.
+                </li>
+                <li>
+                  <strong>Electronic Docs</strong>: Sed tempor accumsan nisl
+                  viverra viverra.
+                </li>
+                <li>
+                  <strong>Authoring Tool</strong>: There is no additional
+                  support for authors within the authoring interface to explain
+                  how this can be done.
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Table 2: Success Criteria, Level AA</h3>
+
+      <h3>Table 3: Success Criteria, Level AAA</h3>
+
+      <h2>Revised Section 508 Report</h2>
+      <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
+
+      <h3>Chapter 4: Hardware</h3>
+
+      Notes: Lorem Ipsum is a web application. Hardware accessibility criteria
+      is not applicable.
+
+      <h3>Chapter 5: Software</h3>
+
+      <h3>Chapter 6: Support Documentation and Services</h3>
+    </main>
+    <footer>
+      <h2>Legal Disclaimer (Fake text Inc.)</h2>
+      The information herein is provided in good faith based on the analysis of
+      the web application at the time of the review and does not represent a
+      legally-binding claim. Please contact us to report any accessibility
+      errors or conformance claim errors for re-evaluation and correction, if
+      necessary.
+    </footer>
+  </body>
+</html>

--- a/tests/examples/valid.html
+++ b/tests/examples/valid.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Lorem Ipsum Accessibility Conformance Report</title>
-    <meta name="description" content="Fake text" />
-  </head>
-  <body>
-    <header>
-      <h1>Lorem Ipsum Accessibility Conformance Report</h1>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Lorem Ipsum Accessibility Conformance Report</title>
+  <meta name="description" content="Fake text">
+</head>
+<body>
+  <header>
+    <h1>Lorem Ipsum Accessibility Conformance Report</h1>
 
-      Based on VPAT® 2.4 Revised Section 508 Edition
-    </header>
-    <main>
-      <h2>Name of Product/Version</h2>
-      Lorem Ipsum 1.1
+    Based on VPAT® 2.4 Revised Section 508 Edition
+  </header>
+  <main>
+    <h2>Name of Product/Version</h2>
+    Lorem Ipsum 1.1
 
-      <h2>Report Date</h2>
-      8/13/2021
+    <h2>Report Date</h2>
+    8/13/2021
 
       <h2>Product Description</h2>
       Fake text
 
-      <h2>Contact Information</h2>
+    <h2>Contact Information</h2>
       <h3>Author Information</h3>
       <ul>
         <li>Name: Cicero</li>
@@ -35,202 +35,131 @@
       </ul>
       <h3>Vendor Information</h3>
       <ul>
-        <li>Company: Fake text Inc.</li>
 
-        <li>Email: contact@example.com</li>
+      <li>Company: Fake text Inc.</li>
+
+      <li>Email: contact@example.com</li>
+
+
       </ul>
 
       <h2>Notes</h2>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet
-      viverra lorem. Nullam laoreet vitae lorem et semper. Donec feugiat rutrum
-      luctus. Nunc nec scelerisque orci. Mauris non tellus congue, vestibulum
-      felis at, consectetur dui. Aenean luctus dictum diam. Vestibulum vehicula
-      leo nulla, nec hendrerit felis sodales a. In hac habitasse platea
-      dictumst. Phasellus odio felis, efficitur a mattis vitae, fermentum vitae
-      libero. Nam ut magna id sem pellentesque ultrices. Nulla sed urna vel
-      tortor vehicula varius. Sed scelerisque porta nisi, sit amet ultricies
-      ante ullamcorper quis.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet viverra lorem. Nullam laoreet vitae lorem et semper. Donec feugiat rutrum luctus. Nunc nec scelerisque orci. Mauris non tellus congue, vestibulum felis at, consectetur dui. Aenean luctus dictum diam. Vestibulum vehicula leo nulla, nec hendrerit felis sodales a. In hac habitasse platea dictumst. Phasellus odio felis, efficitur a mattis vitae, fermentum vitae libero. Nam ut magna id sem pellentesque ultrices. Nulla sed urna vel tortor vehicula varius. Sed scelerisque porta nisi, sit amet ultricies ante ullamcorper quis.
 
       <h2>Evaluation Methods Used</h2>
-      Use of automated tools like WAVE and Accessibility Insights. Manual
-      keyboard only testing. Some testing with JAWS, NVDA and VoiceOver.
+      Use of automated tools like WAVE and Accessibility Insights. Manual keyboard only testing. Some testing with JAWS, NVDA and VoiceOver.
 
-      <h2>Applicable Standards/Guidelines</h2>
-      This report covers the degree of conformance for the following
-      accessibility standard/guidelines:
+    <h2>Applicable Standards/Guidelines</h2>
+    This report covers the degree of conformance for the following accessibility standard/guidelines:
 
-      <table>
-        <thead>
+    <table>
+      <thead>
+        <tr>
+          <th>Standard/Guideline</th>
+          <th>Included In Report</th>
+        </tr>
+      </thead>
+      <tbody>
           <tr>
-            <th>Standard/Guideline</th>
-            <th>Included In Report</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/"
-                >Web Content Accessibility Guidelines 2.0</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>Table 1: Success Criteria, Level A</li>
-                <li>Table 2: Success Criteria, Level AA</li>
-                <li>Table 3: Success Criteria, Level AAA</li>
-              </ul>
-            </td>
+            <td><a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0</a></td>
+            <td><ul><li>Table 1: Success Criteria, Level A</li><li>Table 2: Success Criteria, Level AA</li><li>Table 3: Success Criteria, Level AAA</li></ul></td>
           </tr>
           <tr>
-            <td>
-              <a href="https://www.access-board.gov/ict/"
-                >Revised Section 508 standards published January 18, 2017 and
-                corrected January 22, 2018</a
-              >
-            </td>
-            <td>
-              <ul>
-                <li>Chapter 3: Functional Performance Criteria (FPC)</li>
-                <li>Chapter 4: Hardware</li>
-                <li>Chapter 5: Software</li>
-                <li>Chapter 6: Support Documentation and Services</li>
-              </ul>
-            </td>
+            <td><a href="https://www.access-board.gov/ict/">Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018</a></td>
+            <td><ul><li>Chapter 3: Functional Performance Criteria (FPC)</li><li>Chapter 4: Hardware</li><li>Chapter 5: Software</li><li>Chapter 6: Support Documentation and Services</li></ul></td>
           </tr>
-        </tbody>
-      </table>
+      </tbody>
+    </table>
 
-      <h2>Terms</h2>
-      The terms used in the Conformance Level information are defined as
-      follows:
-      <ul>
-        <li>
-          <strong>Supports</strong>: The functionality of the product has at
-          least one method that meets the criterion without known defects or
-          meets with equivalent facilitation.
-        </li>
-        <li>
-          <strong>Partially Supports</strong>: Some functionality of the product
-          does not meet the criterion.
-        </li>
-        <li>
-          <strong>Does Not Support</strong>: The majority of product
-          functionality does not meet the criterion.
-        </li>
-        <li>
-          <strong>Not Applicable</strong>: The criterion is not relevant to the
-          product.
-        </li>
-        <li>
-          <strong>Not Evaluated</strong>: The product has not been evaluated
-          against the criterion. This can be used only in WCAG 2.0 Level AAA.
-        </li>
-      </ul>
+    <h2>Terms</h2>
+    The terms used in the Conformance Level information are defined as follows:
+    <ul>
+      <li><strong>Supports</strong>: The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.</li>
+      <li><strong>Partially Supports</strong>: Some functionality of the product does not meet the criterion.</li>
+      <li><strong>Does Not Support</strong>: The majority of product functionality does not meet the criterion.</li>
+      <li><strong>Not Applicable</strong>: The criterion is not relevant to the product.</li>
+      <li><strong>Not Evaluated</strong>: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.</li>
+    </ul>
 
       <h2>WCAG 2.0 Report</h2>
-      <h3>Table 1: Success Criteria, Level A</h3>
+          <h3>Table 1: Success Criteria, Level A</h3>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Criteria</th>
-            <th>Conformance Level</th>
-            <th>Remarks and Explanations</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
-                1.1.1 Non-text Content
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Supports</li>
-                <li><strong>Electronic Docs</strong>: Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Supports</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Cras ultrices, diam in laoreet
-                  condimentum, purus leo tempor erat, eu facilisis erat tortor
-                  at purus.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Curabitur tristique tellus
-                  quis ligula elementum, sit amet tincidunt est aliquet.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: Vestibulum sit amet tortor ac
-                  nunc rutrum consequat vel sit amet risus. Nam eget mollis
-                  odio, sit amet bibendum mi. Quisque ac neque a nulla dapibus
-                  imperdiet.
-                </li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
-                1.2.2 Captions (Prerecorded)
-              </a>
-            </td>
-            <td>
-              <ul>
-                <li><strong>Web</strong>: Partially Supports</li>
-                <li><strong>Electronic Docs</strong>: Partially Supports</li>
-                <li><strong>Software</strong>: Not Applicable</li>
-                <li><strong>Authoring Tool</strong>: Does Not Support</li>
-              </ul>
-            </td>
-            <td>
-              <ul>
-                <li>
-                  <strong>Web</strong>: Nam a cursus nulla. Vestibulum tincidunt
-                  tincidunt volutpat.
-                </li>
-                <li>
-                  <strong>Electronic Docs</strong>: Sed tempor accumsan nisl
-                  viverra viverra.
-                </li>
-                <li>
-                  <strong>Authoring Tool</strong>: There is no additional
-                  support for authors within the authoring interface to explain
-                  how this can be done.
-                </li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
 
-      <h3>Table 2: Success Criteria, Level AA</h3>
+              <table>
+                <thead>
+                <tr>
+                  <th>Criteria</th>
+                  <th>Conformance Level</th>
+                  <th>Remarks and Explanations</th>
+                </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">
+                          1.1.1 Non-text Content
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Supports</li>
+                                <li><strong>Electronic Docs</strong>: Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Supports</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Cras ultrices, diam in laoreet condimentum, purus leo tempor erat, eu facilisis erat tortor at purus.</li>
+                              <li><strong>Electronic Docs</strong>: Curabitur tristique tellus quis ligula elementum, sit amet tincidunt est aliquet.</li>
+                              <li><strong>Authoring Tool</strong>: Vestibulum sit amet tortor ac nunc rutrum consequat vel sit amet risus. Nam eget mollis odio, sit amet bibendum mi. Quisque ac neque a nulla dapibus imperdiet.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions">
+                          1.2.2 Captions (Prerecorded)
+                        </a>
+                      </td>
+                      <td>
+                          <ul>
+                                <li><strong>Web</strong>: Partially Supports</li>
+                                <li><strong>Electronic Docs</strong>: Partially Supports</li>
+                                <li><strong>Software</strong>: Not Applicable</li>
+                                <li><strong>Authoring Tool</strong>: Does Not Support</li>
+                          </ul>
+                      </td>
+                      <td>
+                          <ul>
+                              <li><strong>Web</strong>: Nam a cursus nulla. Vestibulum tincidunt tincidunt volutpat.</li>
+                              <li><strong>Electronic Docs</strong>: Sed tempor accumsan nisl viverra viverra.</li>
+                              <li><strong>Authoring Tool</strong>: There is no additional support for authors within the authoring interface to explain how this can be done.</li>
+                          </ul>
+                      </td>
+                    </tr>
+                </tbody>
+              </table>
 
-      <h3>Table 3: Success Criteria, Level AAA</h3>
+          <h3>Table 2: Success Criteria, Level AA</h3>
+
+          <h3>Table 3: Success Criteria, Level AAA</h3>
 
       <h2>Revised Section 508 Report</h2>
-      <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
+          <h3>Chapter 3: Functional Performance Criteria (FPC)</h3>
 
-      <h3>Chapter 4: Hardware</h3>
+          <h3>Chapter 4: Hardware</h3>
 
-      Notes: Lorem Ipsum is a web application. Hardware accessibility criteria
-      is not applicable.
+              Notes: Lorem Ipsum is a web application. Hardware accessibility criteria is not applicable.
 
-      <h3>Chapter 5: Software</h3>
+          <h3>Chapter 5: Software</h3>
 
-      <h3>Chapter 6: Support Documentation and Services</h3>
-    </main>
-    <footer>
+          <h3>Chapter 6: Support Documentation and Services</h3>
+
+  </main>
+  <footer>
       <h2>Legal Disclaimer (Fake text Inc.)</h2>
-      The information herein is provided in good faith based on the analysis of
-      the web application at the time of the review and does not represent a
-      legally-binding claim. Please contact us to report any accessibility
-      errors or conformance claim errors for re-evaluation and correction, if
-      necessary.
-    </footer>
-  </body>
+      The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
+  </footer>
+</body>
 </html>

--- a/tests/opat-output-cli.test.ts
+++ b/tests/opat-output-cli.test.ts
@@ -85,7 +85,7 @@ describe("OPAT CLI test output", () => {
     });
   });
 
-  it("when output file option should return valid output message matching the output file", () => {
+  it("when passed output markdown file option should return valid output message matching the output file", () => {
     const valid = spawn(
       cmd,
       options.concat(
@@ -107,6 +107,32 @@ describe("OPAT CLI test output", () => {
 
       expect(output).to.equal(
         "Valid and output generated at output/valid.markdown!\n"
+      );
+    });
+  });
+
+  it("when passed output HTML file option should return valid output message matching the output file", () => {
+    const valid = spawn(
+      cmd,
+      options.concat(
+        "tests/examples/valid.yaml",
+        "-c",
+        "catalog/2.4-edition-wcag-2.0-508-en.yaml",
+        "-o",
+        "output/valid.html"
+      )
+    );
+    const chunks = [];
+
+    valid.stdout.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    valid.stdout.on("end", () => {
+      const output = Buffer.concat(chunks).toString();
+
+      expect(output).to.equal(
+        "Valid and output generated at output/valid.html!\n"
       );
     });
   });


### PR DESCRIPTION
Created the HTML version of handlebars that has 0 stylings just the bare bones HTML.

I think it can close #15 for now.

GitHub won't render the HTML https://github.com/GSA/open-product-accessibility-template/blob/html-template/opat/drupal-9.html but you can download it from the files or the automation (https://github.com/GSA/open-product-accessibility-template/pull/121/checks?check_run_id=3325619832) and take a look at the file that way.